### PR TITLE
Update to mio 0.8 and os_pipe 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ async-std = { version = "1.9.0", features = ["unstable"], optional = true }
 # Optionally depend on tokio to implement traits for its types for now.
 tokio = { version = "1.6.0", features = ["io-std", "fs", "net", "process"], optional = true }
 # Optionally depend on os_pipe to implement traits for its types for now.
-os_pipe = { version = "0.9.2", optional = true }
+os_pipe = { version = "1.0.0", optional = true }
 # Optionally depend on socket2 to implement traits for its types for now.
 socket2 = { version = "0.4.0", optional = true }
 # Optionally depend on mio to implement traits for its types for now.
-mio = { version = "0.7.11", features = ["net", "os-ext"], optional = true }
+mio = { version = "0.8.0", features = ["net", "os-ext"], optional = true }
 # Optionally depend on fs_err to implement traits for its types for now.
 fs-err = { version = "2.6.0", optional = true }
 

--- a/src/impls_mio.rs
+++ b/src/impls_mio.rs
@@ -110,54 +110,6 @@ impl FromSocket for mio::net::TcpListener {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for mio::net::TcpSocket {
-    #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
-        unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
-    }
-}
-
-#[cfg(windows)]
-impl AsSocket for mio::net::TcpSocket {
-    #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
-        unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
-    }
-}
-
-#[cfg(any(unix, target_os = "wasi"))]
-impl IntoFd for mio::net::TcpSocket {
-    #[inline]
-    fn into_fd(self) -> OwnedFd {
-        unsafe { OwnedFd::from_raw_fd(self.into_raw_fd()) }
-    }
-}
-
-#[cfg(windows)]
-impl IntoSocket for mio::net::TcpSocket {
-    #[inline]
-    fn into_socket(self) -> OwnedSocket {
-        unsafe { OwnedSocket::from_raw_socket(self.into_raw_socket()) }
-    }
-}
-
-#[cfg(any(unix, target_os = "wasi"))]
-impl FromFd for mio::net::TcpSocket {
-    #[inline]
-    fn from_fd(owned: OwnedFd) -> Self {
-        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
-    }
-}
-
-#[cfg(windows)]
-impl FromSocket for mio::net::TcpSocket {
-    #[inline]
-    fn from_socket(owned: OwnedSocket) -> Self {
-        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
-    }
-}
-
-#[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for mio::net::UdpSocket {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {


### PR DESCRIPTION
mio's `TcpSocket` was removed in favor of socket2.