### PR TITLE
Use fine-grained feature detection instead of `rustc_version`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ edition = "2018"
 repository = "https://github.com/sunfishcode/io-lifetimes"
 exclude = ["/.github"]
 
-[build-dependencies]
-rustc_version = "0.4.0"
-
 [dependencies]
 # io-lifetimes only depends on libc/winapi for the ability to close
 # fds/handles/sockets. The following are just optional dependencies to add

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,46 @@
+use std::env::var;
+use std::io::Write;
+
 fn main() {
     // Niche optimizations for `Borrowed*` and `Owned*` depend on `rustc_attrs`
     // which, outside of `std`, are only available on nightly.
-    if let rustc_version::Channel::Nightly = rustc_version::version_meta()
-        .expect("query rustc release channel")
-        .channel
-    {
-        println!("cargo:rustc-cfg=rustc_attrs");
-    }
+    use_feature_or_nothing("rustc_attrs");
 
     // Don't rerun this on changes other than build.rs, as we only depend on
     // the rustc version.
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn use_feature_or_nothing(feature: &str) {
+    if has_feature(feature) {
+        use_feature(feature);
+    }
+}
+
+fn use_feature(feature: &str) {
+    println!("cargo:rustc-cfg={}", feature);
+}
+
+/// Test whether the rustc at `var("RUSTC")` supports the given feature.
+fn has_feature(feature: &str) -> bool {
+    let rustc = var("RUSTC").unwrap();
+
+    #[cfg(not(windows))]
+    let dev_null = "/dev/null";
+    #[cfg(windows)]
+    let dev_null = "NUL";
+
+    let mut child = std::process::Command::new(rustc)
+        .arg("--crate-type=rlib") // Don't require `main`.
+        .arg("--emit=dep-info") // Do as little as possible.
+        .arg("-o")
+        .arg(dev_null) // Don't write an output file.
+        .arg("-") // Read from stdin.
+        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
+        .spawn()
+        .unwrap();
+
+    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+
+    child.wait().unwrap().success()
 }


### PR DESCRIPTION
Test whether rustc supports specific features, rather than assuming that
Nightly has all the features and Stable doesn't.