### PR TITLE
Fix rustc feature detection to work on the beta channel.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,18 +23,14 @@ fn use_feature(feature: &str) {
 
 /// Test whether the rustc at `var("RUSTC")` supports the given feature.
 fn has_feature(feature: &str) -> bool {
+    let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
-
-    #[cfg(not(windows))]
-    let dev_null = "/dev/null";
-    #[cfg(windows)]
-    let dev_null = "NUL";
 
     let mut child = std::process::Command::new(rustc)
         .arg("--crate-type=rlib") // Don't require `main`.
-        .arg("--emit=dep-info") // Do as little as possible.
-        .arg("-o")
-        .arg(dev_null) // Don't write an output file.
+        .arg("--emit=metadata") // Do as little as possible but still parse.
+        .arg("--out-dir")
+        .arg(out_dir) // Put the output somewhere inconsequential.
         .arg("-") // Read from stdin.
         .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
         .spawn()


### PR DESCRIPTION
`--emit=dep-info` wasn't enough to evoke the errors we were expecting,
though only on the beta channel. So use `--emit=metadata` instead.