### PR TITLE
Update to the latest changes in std, including `HandleOrNull`.

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -13,10 +13,10 @@ use std::{
 };
 
 #[cfg(all(unix, feature = "close"))]
-use io_lifetimes::{AsFd, FromFd, IntoFd, OwnedFd};
+use io_lifetimes::{AsFd, FromFd, OwnedFd};
 
 #[cfg(windows)]
-use io_lifetimes::{AsHandle, FromHandle, IntoHandle, OwnedHandle};
+use io_lifetimes::{AsHandle, FromHandle, OwnedHandle};
 #[cfg(windows)]
 use std::{convert::TryInto, ptr::null_mut};
 
@@ -53,15 +53,7 @@ fn main() -> io::Result<()> {
         }
     }
 
-    // Now back to `OwnedFd`.
-    let fd = file.into_fd();
-
-    unsafe {
-        // This isn't needed, since `fd` is owned and would close itself on
-        // drop automatically, but it makes a nice demo of passing an `OwnedFd`
-        // into an FFI call.
-        close(fd);
-    }
+    // `OwnedFd` closes the fd in its `Drop` implementation.
 
     Ok(())
 }
@@ -106,7 +98,7 @@ fn main() -> io::Result<()> {
     let mut file = File::from_handle(handle);
     writeln!(&mut file, "greetings, y'all")?;
 
-    // We can borrow a `BorrowedFd` from a `File`.
+    // We can borrow a `BorrowedHandle` from a `File`.
     unsafe {
         let mut number_of_bytes_written = 0;
         let result = WriteFile(
@@ -123,15 +115,7 @@ fn main() -> io::Result<()> {
         }
     }
 
-    // Now back to `OwnedFd`.
-    let handle = file.into_handle();
-
-    unsafe {
-        // This isn't needed, since `handle` is owned and would close itself on
-        // drop automatically, but it makes a nice demo of passing an `OwnedHandle`
-        // into an FFI call.
-        CloseHandle(handle);
-    }
+    // `OwnedHandle` closes the handle in its `Drop` implementation.
 
     Ok(())
 }

--- a/src/example_ffi.rs
+++ b/src/example_ffi.rs
@@ -30,7 +30,6 @@ extern "C" {
 extern "C" {
     pub fn read(fd: BorrowedFd<'_>, ptr: *mut c_void, size: size_t) -> ssize_t;
     pub fn write(fd: BorrowedFd<'_>, ptr: *const c_void, size: size_t) -> ssize_t;
-    pub fn close(fd: OwnedFd) -> c_int;
 }
 #[cfg(any(unix, target_os = "wasi"))]
 pub use libc::{O_CLOEXEC, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY};
@@ -63,7 +62,6 @@ extern "C" {
         lpNumberOfBytesWritten: LPDWORD,
         lpOverlapped: LPOVERLAPPED,
     ) -> BOOL;
-    pub fn CloseHandle(handle: OwnedHandle) -> BOOL;
 }
 #[cfg(windows)]
 pub use winapi::{

--- a/src/types.rs
+++ b/src/types.rs
@@ -291,7 +291,11 @@ impl TryFrom<HandleOrNull> for OwnedHandle {
     #[inline]
     fn try_from(handle_or_null: HandleOrNull) -> Result<Self, ()> {
         let raw = handle_or_null.0;
-        if raw.is_null() { Err(()) } else { Ok(OwnedHandle { handle: raw }) }
+        if raw.is_null() {
+            Err(())
+        } else {
+            Ok(OwnedHandle { handle: raw })
+        }
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -109,18 +109,21 @@ pub struct OwnedFd {
 ///
 /// This closes the handle on drop.
 ///
-/// This uses `repr(transparent)` and has the representation of a host handle,
-/// so it can be used in FFI in places where a handle is passed as a consumed
-/// argument or returned as an owned value, and is never null.
+/// Note that it *may* have the value `INVALID_HANDLE_VALUE` (-1), which is
+/// sometimes a valid handle value. See [here] for the full story.
 ///
-/// Note that it *may* have the value [`INVALID_HANDLE_VALUE`]. See [here] for
-/// the full story. For APIs like `CreateFileW` which report errors with
-/// `INVALID_HANDLE_VALUE` instead of null, use [`HandleOrInvalid`] instead
-/// of `Option<OwnedHandle>`.
+/// And, it *may* have the value `NULL` (0), which can occur when consoles are
+/// detached from processes, or when `windows_subsystem` is used.
+///
+/// `OwnedHandle` uses [`CloseHandle`] to close its handle on drop. As such,
+/// it must not be used with handles to open registry keys which need to be
+/// closed with [`RegCloseKey`] instead.
+///
+/// [`CloseHandle`]: https://docs.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle
+/// [`RegCloseKey`]: https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regclosekey
 ///
 /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
 #[cfg(windows)]
-#[repr(transparent)]
 pub struct OwnedHandle {
     handle: RawHandle,
 }
@@ -159,11 +162,35 @@ pub struct OwnedSocket {
 /// `INVALID_HANDLE_VALUE`. This ensures that such FFI calls cannot start using the handle without
 /// checking for `INVALID_HANDLE_VALUE` first.
 ///
+/// This type concerns any value other than `INVALID_HANDLE_VALUE` to be valid, including `NULL`.
+/// This is because APIs that use `INVALID_HANDLE_VALUE` as their sentry value may return `NULL`
+/// under `windows_subsystem = "windows"` or other situations where I/O devices are detached.
+///
 /// If this holds a valid handle, it will close the handle on drop.
 #[cfg(windows)]
 #[repr(transparent)]
 #[derive(Debug)]
-pub struct HandleOrInvalid(OwnedHandle);
+pub struct HandleOrInvalid(RawHandle);
+
+/// FFI type for handles in return values or out parameters, where `NULL` is used
+/// as a sentry value to indicate errors, such as in the return value of `CreateThread`. This uses
+/// `repr(transparent)` and has the representation of a host handle, so that it can be used in such
+/// FFI declarations.
+///
+/// The only thing you can usefully do with a `HandleOrNull` is to convert it into an
+/// `OwnedHandle` using its [`TryFrom`] implementation; this conversion takes care of the check for
+/// `NULL`. This ensures that such FFI calls cannot start using the handle without
+/// checking for `NULL` first.
+///
+/// This type concerns any value other than `NULL` to be valid, including `INVALID_HANDLE_VALUE`.
+/// This is because APIs that use `NULL` as their sentry value don't treat `INVALID_HANDLE_VALUE`
+/// as special.
+///
+/// If this holds a valid handle, it will close the handle on drop.
+#[cfg(windows)]
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct HandleOrNull(RawHandle);
 
 // The Windows [`HANDLE`] type may be transferred across and shared between
 // thread boundaries (despite containing a `*mut void`, which in general isn't
@@ -175,11 +202,15 @@ unsafe impl Send for OwnedHandle {}
 #[cfg(windows)]
 unsafe impl Send for HandleOrInvalid {}
 #[cfg(windows)]
+unsafe impl Send for HandleOrNull {}
+#[cfg(windows)]
 unsafe impl Send for BorrowedHandle<'_> {}
 #[cfg(windows)]
 unsafe impl Sync for OwnedHandle {}
 #[cfg(windows)]
 unsafe impl Sync for HandleOrInvalid {}
+#[cfg(windows)]
+unsafe impl Sync for HandleOrNull {}
 #[cfg(windows)]
 unsafe impl Sync for BorrowedHandle<'_> {}
 
@@ -244,12 +275,23 @@ impl TryFrom<HandleOrInvalid> for OwnedHandle {
 
     #[inline]
     fn try_from(handle_or_invalid: HandleOrInvalid) -> Result<Self, ()> {
-        let owned_handle = handle_or_invalid.0;
-        if owned_handle.handle == INVALID_HANDLE_VALUE {
+        let raw = handle_or_invalid.0;
+        if raw == INVALID_HANDLE_VALUE {
             Err(())
         } else {
-            Ok(owned_handle)
+            Ok(OwnedHandle { handle: raw })
         }
+    }
+}
+
+#[cfg(windows)]
+impl TryFrom<HandleOrNull> for OwnedHandle {
+    type Error = ();
+
+    #[inline]
+    fn try_from(handle_or_null: HandleOrNull) -> Result<Self, ()> {
+        let raw = handle_or_null.0;
+        if raw.is_null() { Err(()) } else { Ok(OwnedHandle { handle: raw }) }
     }
 }
 
@@ -356,7 +398,6 @@ impl FromRawHandle for OwnedHandle {
     /// ownership.
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
-        debug_assert!(!handle.is_null());
         Self { handle }
     }
 }
@@ -382,20 +423,42 @@ impl FromRawHandle for HandleOrInvalid {
     /// from a Windows API that uses `INVALID_HANDLE_VALUE` to indicate
     /// failure, such as `CreateFileW`.
     ///
-    /// Use `Option<OwnedHandle>` instead of `HandleOrInvalid` for APIs that
+    /// Use `HandleOrNull` instead of `HandleOrInvalid` for APIs that
     /// use null to indicate failure.
     ///
     /// # Safety
     ///
-    /// The resource pointed to by `raw` must be either open and otherwise
-    /// unowned, or equal to [`INVALID_FILE_HANDLE]`. Note that not all Windows
-    /// APIs use [`INVALID_HANDLE_VALUE`] for errors; see [here] for the full
-    /// story.
+    /// The resource pointed to by `handle` must be either open and otherwise
+    /// unowned, null, or equal to `INVALID_HANDLE_VALUE` (-1). Note that not
+    /// all Windows APIs use `INVALID_HANDLE_VALUE` for errors; see [here] for
+    /// the full story.
     ///
     /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
-        Self(OwnedHandle::from_raw_handle(handle))
+        Self(handle)
+    }
+}
+
+#[cfg(windows)]
+impl FromRawHandle for HandleOrNull {
+    /// Constructs a new instance of `Self` from the given `RawHandle` returned
+    /// from a Windows API that uses null to indicate failure, such as
+    /// `CreateThread`.
+    ///
+    /// Use `HandleOrInvalid` instead of `HandleOrNull` for APIs that
+    /// use `INVALID_HANDLE_VALUE` to indicate failure.
+    ///
+    /// # Safety
+    ///
+    /// The resource pointed to by `handle` must be either open and otherwise
+    /// unowned, or null. Note that not all Windows APIs use null for errors;
+    /// see [here] for the full story.
+    ///
+    /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
+    #[inline]
+    unsafe fn from_raw_handle(handle: RawHandle) -> Self {
+        Self(handle)
     }
 }
 
@@ -423,6 +486,26 @@ impl Drop for OwnedHandle {
     fn drop(&mut self) {
         unsafe {
             let _ = winapi::um::handleapi::CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for HandleOrInvalid {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            let _ = winapi::um::handleapi::CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for HandleOrNull {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            let _ = winapi::um::handleapi::CloseHandle(self.0);
         }
     }
 }


### PR DESCRIPTION
This updates several comments, changes `OwnedHandle` to be
non-transparent, and adds `HandleOrNull`.

This also removes `close` and `CloseHandle` from the example FFI. The
current idea is that those functions will always be called from
`OwnedFd`/`OwnedHandle`/etc. so their FFI bindings can just use
the `RawFd`/`RawHandle` types (and be `unsafe`).