### PR TITLE
Remove the Cargo.toml `[badges]` section.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,3 @@ winapi = { version = "0.3.9", features = ["handleapi", "std", "winsock2"] }
 [features]
 default = ["close"]
 close = ["libc"]
-
-[badges]
-maintenance = { status = "actively-developed" }


### PR DESCRIPTION
These aren't rendered on crates.io anymore, so they aren't useful to
keep around.