### PR TITLE
Support the optional "close" feature on Windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ fs-err = { version = "2.6.0", optional = true }
 libc = { version = "0.2.96", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["handleapi", "std", "winsock2"] }
+winapi = { version = "0.3.9", optional = true, features = ["handleapi", "std", "winsock2"] }
 
 [features]
 default = ["close"]
-close = ["libc"]
+close = ["libc", "winapi"]

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -59,7 +59,7 @@ fn main() -> io::Result<()> {
 }
 
 /// The Windows analog of the above.
-#[cfg(windows)]
+#[cfg(all(windows, feature = "close"))]
 fn main() -> io::Result<()> {
     let handle = unsafe {
         // Open a file, which returns an `HandleOrInvalid`, which we can fallibly
@@ -120,7 +120,10 @@ fn main() -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(all(not(all(rustc_attrs, unix, feature = "close")), not(windows)))]
+#[cfg(all(
+    not(all(rustc_attrs, unix, feature = "close")),
+    not(all(windows, feature = "close"))
+))]
 fn main() {
     println!("On Unix, this example requires Rust nightly (for `rustc_attrs`) and the \"close\" feature.");
 }

--- a/src/example_ffi.rs
+++ b/src/example_ffi.rs
@@ -38,7 +38,7 @@ pub use libc::{O_CLOEXEC, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY};
 /// the return type for `CreateFileW`, since that function is defined to return
 /// [`INVALID_HANDLE_VALUE`] on error instead of null.
 #[cfg(windows)]
-extern "C" {
+extern "system" {
     pub fn CreateFileW(
         lpFileName: LPCWSTR,
         dwDesiredAccess: DWORD,

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,8 +13,13 @@ use std::{
         RawHandle, RawSocket,
     },
 };
-#[cfg(windows)]
+#[cfg(all(windows, feature = "close"))]
 use winapi::{um::handleapi::INVALID_HANDLE_VALUE, um::winsock2::INVALID_SOCKET};
+
+#[cfg(all(windows, not(feature = "winapi")))]
+const INVALID_HANDLE_VALUE: *mut core::ffi::c_void = !0 as _;
+#[cfg(all(windows, not(feature = "winapi")))]
+const INVALID_SOCKET: usize = !0 as _;
 
 /// A borrowed file descriptor.
 ///
@@ -488,8 +493,16 @@ impl Drop for OwnedFd {
 impl Drop for OwnedHandle {
     #[inline]
     fn drop(&mut self) {
+        #[cfg(feature = "close")]
         unsafe {
             let _ = winapi::um::handleapi::CloseHandle(self.handle);
+        }
+
+        // If the `close` feature is disabled, we expect users to avoid letting
+        // `OwnedHandle` instances drop, so that we don't have to call `close`.
+        #[cfg(not(feature = "close"))]
+        {
+            unreachable!("drop called without the \"close\" feature in io-lifetimes");
         }
     }
 }
@@ -498,8 +511,16 @@ impl Drop for OwnedHandle {
 impl Drop for HandleOrInvalid {
     #[inline]
     fn drop(&mut self) {
+        #[cfg(feature = "close")]
         unsafe {
             let _ = winapi::um::handleapi::CloseHandle(self.0);
+        }
+
+        // If the `close` feature is disabled, we expect users to avoid letting
+        // `HandleOrInvalid` instances drop, so that we don't have to call `close`.
+        #[cfg(not(feature = "close"))]
+        {
+            unreachable!("drop called without the \"close\" feature in io-lifetimes");
         }
     }
 }
@@ -508,8 +529,16 @@ impl Drop for HandleOrInvalid {
 impl Drop for HandleOrNull {
     #[inline]
     fn drop(&mut self) {
+        #[cfg(feature = "close")]
         unsafe {
             let _ = winapi::um::handleapi::CloseHandle(self.0);
+        }
+
+        // If the `close` feature is disabled, we expect users to avoid letting
+        // `HandleOrNull` instances drop, so that we don't have to call `close`.
+        #[cfg(not(feature = "close"))]
+        {
+            unreachable!("drop called without the \"close\" feature in io-lifetimes");
         }
     }
 }
@@ -518,8 +547,16 @@ impl Drop for HandleOrNull {
 impl Drop for OwnedSocket {
     #[inline]
     fn drop(&mut self) {
+        #[cfg(feature = "close")]
         unsafe {
             let _ = winapi::um::winsock2::closesocket(self.socket as winapi::um::winsock2::SOCKET);
+        }
+
+        // If the `close` feature is disabled, we expect users to avoid letting
+        // `OwnedSocket` instances drop, so that we don't have to call `close`.
+        #[cfg(not(feature = "close"))]
+        {
+            unreachable!("drop called without the \"close\" feature in io-lifetimes");
         }
     }
 }

--- a/tests/assumptions.rs
+++ b/tests/assumptions.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 
+#[cfg(any(not(windows), feature = "close"))]
 use std::mem::size_of;
 
 #[cfg(unix)]
@@ -22,7 +23,7 @@ fn test_assumptions() {
     );
 }
 
-#[cfg(windows)]
+#[cfg(all(windows, feature = "close"))]
 #[test]
 fn test_assumptions() {
     assert_eq!(


### PR DESCRIPTION
Disabling the  "close" feature makes io-lifetimes not depend on calling
`CloseHandle` or `closesocket`, so that it can sit underneath syscall
wrapping libraries which provide those functions.