### PR TITLE
Disable the `os_pipe` impls on WASI for now.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,16 @@ exclude = ["/.github"]
 async-std = { version = "1.9.0", features = ["unstable"], optional = true }
 # Optionally depend on tokio to implement traits for its types for now.
 tokio = { version = "1.6.0", features = ["io-std", "fs", "net", "process"], optional = true }
-# Optionally depend on os_pipe to implement traits for its types for now.
-os_pipe = { version = "1.0.0", optional = true }
 # Optionally depend on socket2 to implement traits for its types for now.
 socket2 = { version = "0.4.0", optional = true }
 # Optionally depend on mio to implement traits for its types for now.
 mio = { version = "0.8.0", features = ["net", "os-ext"], optional = true }
 # Optionally depend on fs_err to implement traits for its types for now.
 fs-err = { version = "2.6.0", optional = true }
+
+[target.'cfg(not(target_os = "wasi"))'.dependencies]
+# Optionally depend on os_pipe to implement traits for its types for now.
+os_pipe = { version = "1.0.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2.96", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,7 @@ mod impls_fs_err;
 #[cfg(not(io_lifetimes_use_std))]
 #[cfg(feature = "mio")]
 mod impls_mio;
+#[cfg(not(target_os = "wasi"))]
 #[cfg(not(io_lifetimes_use_std))]
 #[cfg(feature = "os_pipe")]
 mod impls_os_pipe;


### PR DESCRIPTION
WASI doesn't yet support pipes, so os_pipe doesn't currently compile
under WASI, so disable the io-lifetimes impls for os_pipe on WASI for
now.