### PR TITLE
Port `try_clone` to io-lifetimes.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - run: cargo test --workspace --all-features
+    - run: cargo test --workspace --no-default-features
 
   test_use_std:
     name: Test with std's types and traits
@@ -74,3 +75,4 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - run: cargo test --workspace --all-features
+    - run: cargo test --workspace --no-default-features


### PR DESCRIPTION
Port std's `try_clone`, added in rust-lang/rust#88794, to io-lifetimes.

This puts the actua clone logic under control of `feature = "close"`, as
it has a similar circular dependency issue with rustix.