### PR TITLE
Change `as_fd` from `&self` to `self`.

### DIFF
--- a/examples/flexible-apis.rs
+++ b/examples/flexible-apis.rs
@@ -27,7 +27,7 @@ fn use_fd_a(fd: BorrowedFd<'_>) {
 /// it has the advantage of allowing users to pass in any type implementing
 /// `AsFd` directly, without having to call `.as_fd()` themselves.
 #[cfg(all(feature = "close", not(windows)))]
-fn use_fd_b<Fd: AsFd>(fd: &Fd) {
+fn use_fd_b<'a, Fd: AsFd<'a>>(fd: Fd) {
     let _ = fd.as_fd();
 }
 
@@ -63,7 +63,7 @@ fn main() {
     use_fd_b(&f);
 
     // Of course, users can still pass in `BorrowedFd` values if they want to.
-    use_fd_b(&f.as_fd());
+    use_fd_b(f.as_fd());
 
     let a = std::fs::File::open("Cargo.toml").unwrap();
     let b = std::fs::File::open("Cargo.toml").unwrap();

--- a/examples/owning-wrapper.rs
+++ b/examples/owning-wrapper.rs
@@ -26,9 +26,9 @@ struct Thing {
 }
 
 #[cfg(not(windows))]
-impl AsFd for Thing {
+impl<'a> AsFd<'a> for &'a Thing {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.filelike.as_fd()
     }
 }
@@ -50,9 +50,9 @@ impl FromFd for Thing {
 }
 
 #[cfg(windows)]
-impl AsHandle for Thing {
+impl<'a> AsHandle<'a> for &'a Thing {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         self.filelike.as_handle()
     }
 }

--- a/src/impls_async_std.rs
+++ b/src/impls_async_std.rs
@@ -19,17 +19,17 @@ use std::os::windows::io::{
 };
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for async_std::fs::File {
+impl<'a> AsFd<'a> for &'a async_std::fs::File {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for async_std::fs::File {
+impl<'a> AsHandle<'a> for &'a async_std::fs::File {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
@@ -67,17 +67,17 @@ impl FromHandle for async_std::fs::File {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for async_std::net::TcpStream {
+impl<'a> AsFd<'a> for &'a async_std::net::TcpStream {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for async_std::net::TcpStream {
+impl<'a> AsSocket<'a> for &'a async_std::net::TcpStream {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -115,17 +115,17 @@ impl FromSocket for async_std::net::TcpStream {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for async_std::net::TcpListener {
+impl<'a> AsFd<'a> for &'a async_std::net::TcpListener {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for async_std::net::TcpListener {
+impl<'a> AsSocket<'a> for &'a async_std::net::TcpListener {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -163,17 +163,17 @@ impl FromSocket for async_std::net::TcpListener {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for async_std::net::UdpSocket {
+impl<'a> AsFd<'a> for &'a async_std::net::UdpSocket {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for async_std::net::UdpSocket {
+impl<'a> AsSocket<'a> for &'a async_std::net::UdpSocket {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -211,57 +211,57 @@ impl FromSocket for async_std::net::UdpSocket {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for async_std::io::Stdin {
+impl<'a> AsFd<'a> for &'a async_std::io::Stdin {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for async_std::io::Stdin {
+impl<'a> AsHandle<'a> for &'a async_std::io::Stdin {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for async_std::io::Stdout {
+impl<'a> AsFd<'a> for &'a async_std::io::Stdout {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for async_std::io::Stdout {
+impl<'a> AsHandle<'a> for &'a async_std::io::Stdout {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for async_std::io::Stderr {
+impl<'a> AsFd<'a> for &'a async_std::io::Stderr {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for async_std::io::Stderr {
+impl<'a> AsHandle<'a> for &'a async_std::io::Stderr {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(unix)]
-impl AsFd for async_std::os::unix::net::UnixStream {
+impl<'a> AsFd<'a> for &'a async_std::os::unix::net::UnixStream {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
@@ -283,9 +283,9 @@ impl FromFd for async_std::os::unix::net::UnixStream {
 }
 
 #[cfg(unix)]
-impl AsFd for async_std::os::unix::net::UnixListener {
+impl<'a> AsFd<'a> for &'a async_std::os::unix::net::UnixListener {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
@@ -307,9 +307,9 @@ impl FromFd for async_std::os::unix::net::UnixListener {
 }
 
 #[cfg(unix)]
-impl AsFd for async_std::os::unix::net::UnixDatagram {
+impl<'a> AsFd<'a> for &'a async_std::os::unix::net::UnixDatagram {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }

--- a/src/impls_fs_err.rs
+++ b/src/impls_fs_err.rs
@@ -14,17 +14,17 @@ use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for fs_err::File {
+impl<'a> AsFd<'a> for &'a fs_err::File {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for fs_err::File {
+impl<'a> AsHandle<'a> for &'a fs_err::File {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }

--- a/src/impls_mio.rs
+++ b/src/impls_mio.rs
@@ -14,17 +14,17 @@ use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket};
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for mio::net::TcpStream {
+impl<'a> AsFd<'a> for &'a mio::net::TcpStream {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for mio::net::TcpStream {
+impl<'a> AsSocket<'a> for &'a mio::net::TcpStream {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -62,17 +62,17 @@ impl FromSocket for mio::net::TcpStream {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for mio::net::TcpListener {
+impl<'a> AsFd<'a> for &'a mio::net::TcpListener {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for mio::net::TcpListener {
+impl<'a> AsSocket<'a> for &'a mio::net::TcpListener {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -110,17 +110,17 @@ impl FromSocket for mio::net::TcpListener {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for mio::net::UdpSocket {
+impl<'a> AsFd<'a> for &'a mio::net::UdpSocket {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for mio::net::UdpSocket {
+impl<'a> AsSocket<'a> for &'a mio::net::UdpSocket {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -158,9 +158,9 @@ impl FromSocket for mio::net::UdpSocket {
 }
 
 #[cfg(unix)]
-impl AsFd for mio::net::UnixDatagram {
+impl<'a> AsFd<'a> for &'a mio::net::UnixDatagram {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
@@ -182,9 +182,9 @@ impl FromFd for mio::net::UnixDatagram {
 }
 
 #[cfg(unix)]
-impl AsFd for mio::net::UnixListener {
+impl<'a> AsFd<'a> for &'a mio::net::UnixListener {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
@@ -206,9 +206,9 @@ impl FromFd for mio::net::UnixListener {
 }
 
 #[cfg(unix)]
-impl AsFd for mio::net::UnixStream {
+impl<'a> AsFd<'a> for &'a mio::net::UnixStream {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
@@ -230,9 +230,9 @@ impl FromFd for mio::net::UnixStream {
 }
 
 #[cfg(unix)]
-impl AsFd for mio::unix::pipe::Receiver {
+impl<'a> AsFd<'a> for &'a mio::unix::pipe::Receiver {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
@@ -254,9 +254,9 @@ impl FromFd for mio::unix::pipe::Receiver {
 }
 
 #[cfg(unix)]
-impl AsFd for mio::unix::pipe::Sender {
+impl<'a> AsFd<'a> for &'a mio::unix::pipe::Sender {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }

--- a/src/impls_os_pipe.rs
+++ b/src/impls_os_pipe.rs
@@ -14,17 +14,17 @@ use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for os_pipe::PipeReader {
+impl<'a> AsFd<'a> for &'a os_pipe::PipeReader {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for os_pipe::PipeReader {
+impl<'a> AsHandle<'a> for &'a os_pipe::PipeReader {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
@@ -62,17 +62,17 @@ impl FromHandle for os_pipe::PipeReader {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for os_pipe::PipeWriter {
+impl<'a> AsFd<'a> for &'a os_pipe::PipeWriter {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for os_pipe::PipeWriter {
+impl<'a> AsHandle<'a> for &'a os_pipe::PipeWriter {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }

--- a/src/impls_socket2.rs
+++ b/src/impls_socket2.rs
@@ -14,17 +14,17 @@ use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket};
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for socket2::Socket {
+impl<'a> AsFd<'a> for &'a socket2::Socket {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for socket2::Socket {
+impl<'a> AsSocket<'a> for &'a socket2::Socket {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }

--- a/src/impls_std.rs
+++ b/src/impls_std.rs
@@ -328,7 +328,7 @@ impl<'a> AsHandle<'a> for &'a std::io::Stdin {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl<'a> AsFd<'a> for &'a std::io::StdinLock<'a> {
+impl<'a, 'b> AsFd<'a> for &'a std::io::StdinLock<'b> {
     #[inline]
     fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
@@ -336,7 +336,7 @@ impl<'a> AsFd<'a> for &'a std::io::StdinLock<'a> {
 }
 
 #[cfg(windows)]
-impl<'a> AsHandle<'a> for &'a std::io::StdinLock<'a> {
+impl<'a, 'b> AsHandle<'a> for &'a std::io::StdinLock<'b> {
     #[inline]
     fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
@@ -360,7 +360,7 @@ impl<'a> AsHandle<'a> for &'a std::io::Stdout {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl<'a> AsFd<'a> for &'a std::io::StdoutLock<'a> {
+impl<'a, 'b> AsFd<'a> for &'a std::io::StdoutLock<'b> {
     #[inline]
     fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
@@ -368,7 +368,7 @@ impl<'a> AsFd<'a> for &'a std::io::StdoutLock<'a> {
 }
 
 #[cfg(windows)]
-impl<'a> AsHandle<'a> for &'a std::io::StdoutLock<'a> {
+impl<'a, 'b> AsHandle<'a> for &'a std::io::StdoutLock<'b> {
     #[inline]
     fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
@@ -392,7 +392,7 @@ impl<'a> AsHandle<'a> for &'a std::io::Stderr {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl<'a> AsFd<'a> for &'a std::io::StderrLock<'a> {
+impl<'a, 'b> AsFd<'a> for &'a std::io::StderrLock<'b> {
     #[inline]
     fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
@@ -400,7 +400,7 @@ impl<'a> AsFd<'a> for &'a std::io::StderrLock<'a> {
 }
 
 #[cfg(windows)]
-impl<'a> AsHandle<'a> for &'a std::io::StderrLock<'a> {
+impl<'a, 'b> AsHandle<'a> for &'a std::io::StderrLock<'b> {
     #[inline]
     fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }

--- a/src/impls_std.rs
+++ b/src/impls_std.rs
@@ -16,49 +16,49 @@ use std::os::windows::io::{
 };
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for BorrowedFd<'_> {
+impl<'a> AsFd<'a> for BorrowedFd<'a> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for BorrowedHandle<'_> {
+impl<'a> AsHandle<'a> for BorrowedHandle<'a> {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for BorrowedSocket<'_> {
+impl<'a> AsSocket<'a> for BorrowedSocket<'a> {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for OwnedFd {
+impl<'a> AsFd<'a> for &'a OwnedFd {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for OwnedHandle {
+impl<'a> AsHandle<'a> for &'a OwnedHandle {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for OwnedSocket {
+impl<'a> AsSocket<'a> for &'a OwnedSocket {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -120,17 +120,17 @@ impl FromHandle for HandleOrInvalid {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for std::fs::File {
+impl<'a> AsFd<'a> for &'a std::fs::File {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for std::fs::File {
+impl<'a> AsHandle<'a> for &'a std::fs::File {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
@@ -168,17 +168,17 @@ impl FromHandle for std::fs::File {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for std::net::TcpStream {
+impl<'a> AsFd<'a> for &'a std::net::TcpStream {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for std::net::TcpStream {
+impl<'a> AsSocket<'a> for &'a std::net::TcpStream {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -216,17 +216,17 @@ impl FromSocket for std::net::TcpStream {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for std::net::TcpListener {
+impl<'a> AsFd<'a> for &'a std::net::TcpListener {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for std::net::TcpListener {
+impl<'a> AsSocket<'a> for &'a std::net::TcpListener {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -264,17 +264,17 @@ impl FromSocket for std::net::TcpListener {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for std::net::UdpSocket {
+impl<'a> AsFd<'a> for &'a std::net::UdpSocket {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for std::net::UdpSocket {
+impl<'a> AsSocket<'a> for &'a std::net::UdpSocket {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -312,113 +312,113 @@ impl FromSocket for std::net::UdpSocket {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for std::io::Stdin {
+impl<'a> AsFd<'a> for &'a std::io::Stdin {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for std::io::Stdin {
+impl<'a> AsHandle<'a> for &'a std::io::Stdin {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl<'a> AsFd for std::io::StdinLock<'a> {
+impl<'a> AsFd<'a> for &'a std::io::StdinLock<'a> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl<'a> AsHandle for std::io::StdinLock<'a> {
+impl<'a> AsHandle<'a> for &'a std::io::StdinLock<'a> {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for std::io::Stdout {
+impl<'a> AsFd<'a> for &'a std::io::Stdout {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for std::io::Stdout {
+impl<'a> AsHandle<'a> for &'a std::io::Stdout {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl<'a> AsFd for std::io::StdoutLock<'a> {
+impl<'a> AsFd<'a> for &'a std::io::StdoutLock<'a> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl<'a> AsHandle for std::io::StdoutLock<'a> {
+impl<'a> AsHandle<'a> for &'a std::io::StdoutLock<'a> {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for std::io::Stderr {
+impl<'a> AsFd<'a> for &'a std::io::Stderr {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for std::io::Stderr {
+impl<'a> AsHandle<'a> for &'a std::io::Stderr {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl<'a> AsFd for std::io::StderrLock<'a> {
+impl<'a> AsFd<'a> for &'a std::io::StderrLock<'a> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl<'a> AsHandle for std::io::StderrLock<'a> {
+impl<'a> AsHandle<'a> for &'a std::io::StderrLock<'a> {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(unix)]
-impl AsFd for std::process::ChildStdin {
+impl<'a> AsFd<'a> for &'a std::process::ChildStdin {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for std::process::ChildStdin {
+impl<'a> AsHandle<'a> for &'a std::process::ChildStdin {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
@@ -440,17 +440,17 @@ impl IntoHandle for std::process::ChildStdin {
 }
 
 #[cfg(unix)]
-impl AsFd for std::process::ChildStdout {
+impl<'a> AsFd<'a> for &'a std::process::ChildStdout {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for std::process::ChildStdout {
+impl<'a> AsHandle<'a> for &'a std::process::ChildStdout {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
@@ -472,17 +472,17 @@ impl IntoHandle for std::process::ChildStdout {
 }
 
 #[cfg(unix)]
-impl AsFd for std::process::ChildStderr {
+impl<'a> AsFd<'a> for &'a std::process::ChildStderr {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for std::process::ChildStderr {
+impl<'a> AsHandle<'a> for &'a std::process::ChildStderr {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
@@ -520,9 +520,9 @@ impl FromHandle for std::process::Stdio {
 }
 
 #[cfg(windows)]
-impl AsHandle for std::process::Child {
+impl<'a> AsHandle<'a> for &'a std::process::Child {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
@@ -536,9 +536,9 @@ impl IntoHandle for std::process::Child {
 }
 
 #[cfg(unix)]
-impl AsFd for std::os::unix::net::UnixStream {
+impl<'a> AsFd<'a> for &'a std::os::unix::net::UnixStream {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
@@ -560,9 +560,9 @@ impl FromFd for std::os::unix::net::UnixStream {
 }
 
 #[cfg(unix)]
-impl AsFd for std::os::unix::net::UnixListener {
+impl<'a> AsFd<'a> for &'a std::os::unix::net::UnixListener {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
@@ -584,9 +584,9 @@ impl FromFd for std::os::unix::net::UnixListener {
 }
 
 #[cfg(unix)]
-impl AsFd for std::os::unix::net::UnixDatagram {
+impl<'a> AsFd<'a> for &'a std::os::unix::net::UnixDatagram {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
@@ -608,9 +608,9 @@ impl FromFd for std::os::unix::net::UnixDatagram {
 }
 
 #[cfg(windows)]
-impl<T> AsHandle for std::thread::JoinHandle<T> {
+impl<'a, T> AsHandle<'a> for &'a std::thread::JoinHandle<T> {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }

--- a/src/impls_tokio.rs
+++ b/src/impls_tokio.rs
@@ -14,17 +14,17 @@ use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::windows::io::{AsRawHandle, AsRawSocket, FromRawHandle, IntoRawHandle};
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for tokio::fs::File {
+impl<'a> AsFd<'a> for &'a tokio::fs::File {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for tokio::fs::File {
+impl<'a> AsHandle<'a> for &'a tokio::fs::File {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
@@ -46,153 +46,153 @@ impl FromHandle for tokio::fs::File {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for tokio::net::TcpStream {
+impl<'a> AsFd<'a> for &'a tokio::net::TcpStream {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for tokio::net::TcpStream {
+impl<'a> AsSocket<'a> for &'a tokio::net::TcpStream {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for tokio::net::TcpListener {
+impl<'a> AsFd<'a> for &'a tokio::net::TcpListener {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for tokio::net::TcpListener {
+impl<'a> AsSocket<'a> for &'a tokio::net::TcpListener {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for tokio::net::UdpSocket {
+impl<'a> AsFd<'a> for &'a tokio::net::UdpSocket {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsSocket for tokio::net::UdpSocket {
+impl<'a> AsSocket<'a> for &'a tokio::net::UdpSocket {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for tokio::io::Stdin {
+impl<'a> AsFd<'a> for &'a tokio::io::Stdin {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for tokio::io::Stdin {
+impl<'a> AsHandle<'a> for &'a tokio::io::Stdin {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for tokio::io::Stdout {
+impl<'a> AsFd<'a> for &'a tokio::io::Stdout {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for tokio::io::Stdout {
+impl<'a> AsHandle<'a> for &'a tokio::io::Stdout {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for tokio::io::Stderr {
+impl<'a> AsFd<'a> for &'a tokio::io::Stderr {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for tokio::io::Stderr {
+impl<'a> AsHandle<'a> for &'a tokio::io::Stderr {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(unix)]
-impl AsFd for tokio::net::UnixStream {
+impl<'a> AsFd<'a> for &'a tokio::net::UnixStream {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(unix)]
-impl AsFd for tokio::net::UnixListener {
+impl<'a> AsFd<'a> for &'a tokio::net::UnixListener {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(unix)]
-impl AsFd for tokio::net::UnixDatagram {
+impl<'a> AsFd<'a> for &'a tokio::net::UnixDatagram {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl AsFd for tokio::process::ChildStdout {
+impl<'a> AsFd<'a> for &'a tokio::process::ChildStdout {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(self.as_raw_fd()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for tokio::process::ChildStdin {
+impl<'a> AsHandle<'a> for &'a tokio::process::ChildStdin {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for tokio::process::ChildStdout {
+impl<'a> AsHandle<'a> for &'a tokio::process::ChildStdout {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
 #[cfg(windows)]
-impl AsHandle for tokio::process::ChildStderr {
+impl<'a> AsHandle<'a> for &'a tokio::process::ChildStderr {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }

--- a/src/portability.rs
+++ b/src/portability.rs
@@ -77,7 +77,7 @@ pub type OwnedSocketlike = OwnedSocket;
 /// `AsHandle`. It also provides the `as_filelike_view` convenience function
 /// providing typed views.
 #[cfg(any(unix, target_os = "wasi"))]
-pub trait AsFilelike: AsFd {
+pub trait AsFilelike<'a>: AsFd<'a> {
     /// Borrows the reference.
     ///
     /// # Example
@@ -91,24 +91,24 @@ pub trait AsFilelike: AsFd {
     /// let borrowed_filelike: BorrowedFilelike<'_> = f.as_filelike();
     /// # Ok::<(), io::Error>(())
     /// ```
-    fn as_filelike(&self) -> BorrowedFilelike<'_>;
+    fn as_filelike(self) -> BorrowedFilelike<'a>;
 
     /// Return a borrowing view of a resource which dereferences to a `&Target`
     /// or `&mut Target`.
     ///
     /// [`File`]: std::fs::File
-    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(&self) -> FilelikeView<'_, Target>;
+    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(self) -> FilelikeView<'a, Target>;
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl<T: AsFd> AsFilelike for T {
+impl<'a, T: AsFd<'a>> AsFilelike<'a> for T {
     #[inline]
-    fn as_filelike(&self) -> BorrowedFilelike<'_> {
+    fn as_filelike(self) -> BorrowedFilelike<'a> {
         self.as_fd()
     }
 
     #[inline]
-    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(&self) -> FilelikeView<'_, Target> {
+    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(self) -> FilelikeView<'a, Target> {
         FilelikeView::new(self)
     }
 }
@@ -119,7 +119,7 @@ impl<T: AsFd> AsFilelike for T {
 /// [`AsHandle`]. It also provides the `as_filelike_view` convenience function
 /// providing typed views.
 #[cfg(windows)]
-pub trait AsFilelike: AsHandle {
+pub trait AsFilelike<'a>: AsHandle<'a> {
     /// Borrows the reference.
     ///
     /// # Example
@@ -133,24 +133,24 @@ pub trait AsFilelike: AsHandle {
     /// let borrowed_filelike: BorrowedFilelike<'_> = f.as_filelike();
     /// # Ok::<(), io::Error>(())
     /// ```
-    fn as_filelike(&self) -> BorrowedFilelike<'_>;
+    fn as_filelike(self) -> BorrowedFilelike<'a>;
 
     /// Return a borrowing view of a resource which dereferences to a `&Target`
     /// or `&mut Target`.
     ///
     /// [`File`]: std::fs::File
-    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(&self) -> FilelikeView<'_, Target>;
+    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(self) -> FilelikeView<'a, Target>;
 }
 
 #[cfg(windows)]
-impl<T: AsHandle> AsFilelike for T {
+impl<'a, T: AsHandle<'a>> AsFilelike<'a> for T {
     #[inline]
-    fn as_filelike(&self) -> BorrowedFilelike<'_> {
+    fn as_filelike(self) -> BorrowedFilelike<'a> {
         self.as_handle()
     }
 
     #[inline]
-    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(&self) -> FilelikeView<'_, Target> {
+    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(self) -> FilelikeView<'a, Target> {
         FilelikeView::new(self)
     }
 }
@@ -162,30 +162,30 @@ impl<T: AsHandle> AsFilelike for T {
 /// `AsSocket`. It also provides the `as_socketlike_view` convenience
 /// function providing typed views.
 #[cfg(any(unix, target_os = "wasi"))]
-pub trait AsSocketlike: AsFd {
+pub trait AsSocketlike<'a>: AsFd<'a> {
     /// Borrows the reference.
-    fn as_socketlike(&self) -> BorrowedSocketlike<'_>;
+    fn as_socketlike(self) -> BorrowedSocketlike<'a>;
 
     /// Return a borrowing view of a resource which dereferences to a `&Target`
     /// or `&mut Target`.
     ///
     /// [`TcpStream`]: std::net::TcpStream
     fn as_socketlike_view<Target: FromSocketlike + IntoSocketlike>(
-        &self,
-    ) -> SocketlikeView<'_, Target>;
+        self,
+    ) -> SocketlikeView<'a, Target>;
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-impl<T: AsFd> AsSocketlike for T {
+impl<'a, T: AsFd<'a>> AsSocketlike<'a> for T {
     #[inline]
-    fn as_socketlike(&self) -> BorrowedSocketlike<'_> {
+    fn as_socketlike(self) -> BorrowedSocketlike<'a> {
         self.as_fd()
     }
 
     #[inline]
     fn as_socketlike_view<Target: FromSocketlike + IntoSocketlike>(
-        &self,
-    ) -> SocketlikeView<'_, Target> {
+        self,
+    ) -> SocketlikeView<'a, Target> {
         SocketlikeView::new(self)
     }
 }
@@ -197,30 +197,30 @@ impl<T: AsFd> AsSocketlike for T {
 /// [`AsSocket`]. It also provides the `as_socketlike_view` convenience
 /// function providing typed views.
 #[cfg(windows)]
-pub trait AsSocketlike: AsSocket {
+pub trait AsSocketlike<'a>: AsSocket<'a> {
     /// Borrows the reference.
-    fn as_socketlike(&self) -> BorrowedSocketlike;
+    fn as_socketlike(self) -> BorrowedSocketlike<'a>;
 
     /// Return a borrowing view of a resource which dereferences to a `&Target`
     /// or `&mut Target`.
     ///
     /// [`TcpStream`]: std::net::TcpStream
     fn as_socketlike_view<Target: FromSocketlike + IntoSocketlike>(
-        &self,
-    ) -> SocketlikeView<'_, Target>;
+        self,
+    ) -> SocketlikeView<'a, Target>;
 }
 
 #[cfg(windows)]
-impl<T: AsSocket> AsSocketlike for T {
+impl<'a, T: AsSocket<'a>> AsSocketlike<'a> for T {
     #[inline]
-    fn as_socketlike(&self) -> BorrowedSocketlike<'_> {
+    fn as_socketlike(self) -> BorrowedSocketlike<'a> {
         self.as_socket()
     }
 
     #[inline]
     fn as_socketlike_view<Target: FromSocketlike + IntoSocketlike>(
-        &self,
-    ) -> SocketlikeView<'_, Target> {
+        self,
+    ) -> SocketlikeView<'a, Target> {
         SocketlikeView::new(self)
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -16,7 +16,7 @@ use crate::{OwnedHandle, OwnedSocket};
 /// `AsSocket` set of traits.
 #[cfg(not(io_lifetimes_use_std))]
 #[cfg(any(unix, target_os = "wasi"))]
-pub trait AsFd {
+pub trait AsFd<'a> {
     /// Borrows the file descriptor.
     ///
     /// # Example
@@ -31,13 +31,13 @@ pub trait AsFd {
     /// let borrowed_fd: BorrowedFd<'_> = f.as_fd();
     /// # Ok::<(), io::Error>(())
     /// ```
-    fn as_fd(&self) -> BorrowedFd<'_>;
+    fn as_fd(self) -> BorrowedFd<'a>;
 }
 
 /// A trait to borrow the handle from an underlying object.
 #[cfg(not(io_lifetimes_use_std))]
 #[cfg(windows)]
-pub trait AsHandle {
+pub trait AsHandle<'a> {
     /// Borrows the handle.
     ///
     /// # Example
@@ -52,15 +52,15 @@ pub trait AsHandle {
     /// let borrowed_handle: BorrowedHandle<'_> = f.as_handle();
     /// # Ok::<(), io::Error>(())
     /// ```
-    fn as_handle(&self) -> BorrowedHandle<'_>;
+    fn as_handle(self) -> BorrowedHandle<'a>;
 }
 
 /// A trait to borrow the socket from an underlying object.
 #[cfg(not(io_lifetimes_use_std))]
 #[cfg(windows)]
-pub trait AsSocket {
+pub trait AsSocket<'a> {
     /// Borrows the socket.
-    fn as_socket(&self) -> BorrowedSocket<'_>;
+    fn as_socket(self) -> BorrowedSocket<'a>;
 }
 
 /// A trait to express the ability to consume an object and acquire ownership

--- a/src/views.rs
+++ b/src/views.rs
@@ -48,10 +48,10 @@ pub struct SocketlikeView<'socketlike, Target: FromSocketlike + IntoSocketlike> 
     _phantom: PhantomData<&'socketlike OwnedSocketlike>,
 }
 
-impl<Target: FromFilelike + IntoFilelike> FilelikeView<'_, Target> {
+impl<'a, Target: FromFilelike + IntoFilelike> FilelikeView<'a, Target> {
     /// Construct a temporary `Target` and wrap it in a `FilelikeView` object.
     #[inline]
-    pub(crate) fn new<T: AsFilelike>(filelike: &T) -> Self {
+    pub(crate) fn new<T: AsFilelike<'a>>(filelike: T) -> Self {
         // Safety: The returned `FilelikeView` is scoped to the lifetime of
         // `filelike`, which we've borrowed here, so the view won't outlive
         // the object it's borrowed from.
@@ -76,11 +76,11 @@ impl<Target: FromFilelike + IntoFilelike> FilelikeView<'_, Target> {
 }
 
 #[cfg(windows)]
-impl<Target: FromSocketlike + IntoSocketlike> SocketlikeView<'_, Target> {
+impl<'a, Target: FromSocketlike + IntoSocketlike> SocketlikeView<'a, Target> {
     /// Construct a temporary `Target` and wrap it in a `SocketlikeView`
     /// object.
     #[inline]
-    pub(crate) fn new<T: AsSocketlike>(socketlike: &T) -> Self {
+    pub(crate) fn new<T: AsSocketlike<'a>>(socketlike: T) -> Self {
         // Safety: The returned `SocketlikeView` is scoped to the lifetime of
         // `socketlike`, which we've borrowed here, so the view won't outlive
         // the object it's borrowed from.

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -11,7 +11,7 @@ use io_lifetimes::{
 
 struct Tester {}
 impl Tester {
-    fn use_file<Filelike: AsFilelike>(filelike: &Filelike) {
+    fn use_file<'a, Filelike: AsFilelike<'a>>(filelike: Filelike) {
         let filelike = filelike.as_filelike();
         let _ = filelike.as_filelike_view::<std::fs::File>();
         let _ = unsafe {
@@ -24,7 +24,7 @@ impl Tester {
         let _ = dbg!(filelike);
     }
 
-    fn use_socket<Socketlike: AsSocketlike>(socketlike: &Socketlike) {
+    fn use_socket<'a, Socketlike: AsSocketlike<'a>>(socketlike: Socketlike) {
         let socketlike = socketlike.as_socketlike();
         let _ = socketlike.as_socketlike_view::<std::net::TcpStream>();
         let _ = unsafe {
@@ -64,16 +64,16 @@ impl Tester {
 fn test_api() {
     let file = std::fs::File::open("Cargo.toml").unwrap();
     Tester::use_file(&file);
-    Tester::use_file(&file.as_filelike());
+    Tester::use_file(file.as_filelike());
     Tester::use_file(&*file.as_filelike_view::<std::fs::File>());
-    Tester::use_file(&file.as_filelike_view::<std::fs::File>().as_filelike());
+    Tester::use_file(file.as_filelike_view::<std::fs::File>().as_filelike());
 
     let socket = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     Tester::use_socket(&socket);
-    Tester::use_socket(&socket.as_socketlike());
+    Tester::use_socket(socket.as_socketlike());
     Tester::use_socket(&*socket.as_socketlike_view::<std::net::TcpListener>());
     Tester::use_socket(
-        &socket
+        socket
             .as_socketlike_view::<std::net::TcpListener>()
             .as_socketlike(),
     );


### PR DESCRIPTION
Change from

```rust
trait AsFd {
    fn as_fd(&self) -> BorrowedFd<'_>;
}
```

to

```rust
trait AsFd<'a> {
    fn as_fd(self) -> BorrowedFd<'a>;
}
```

and similar for `AsHandle`, `AsSocket`, `AsFilelike`, and
`AsSocketlike`. Instead of implementing `AsFd` for `OwnedFd` and other
owning types, it's now implemented for `&'a OwnedFd` and similar
references to other owning types.

This means somewhat more typing for implementors of the traits, but it
means fewer `&`s for users of APIs using the traits, and it means fewer
"reference to reference" situations.