### PR TITLE
Implement `AsFd` for `&T` and `&mut T`.

### DIFF
--- a/examples/flexible-apis.rs
+++ b/examples/flexible-apis.rs
@@ -27,7 +27,7 @@ fn use_fd_a(fd: BorrowedFd<'_>) {
 /// it has the advantage of allowing users to pass in any type implementing
 /// `AsFd` directly, without having to call `.as_fd()` themselves.
 #[cfg(all(feature = "close", not(windows)))]
-fn use_fd_b<Fd: AsFd>(fd: &Fd) {
+fn use_fd_b<Fd: AsFd>(fd: Fd) {
     let _ = fd.as_fd();
 }
 
@@ -63,7 +63,7 @@ fn main() {
     use_fd_b(&f);
 
     // Of course, users can still pass in `BorrowedFd` values if they want to.
-    use_fd_b(&f.as_fd());
+    use_fd_b(f.as_fd());
 
     let a = std::fs::File::open("Cargo.toml").unwrap();
     let b = std::fs::File::open("Cargo.toml").unwrap();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -218,3 +218,51 @@ pub trait FromSocket {
         Self::from_socket(into_owned.into_socket())
     }
 }
+
+#[cfg(not(windows))]
+impl<T: AsFd> AsFd for &T {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        T::as_fd(self)
+    }
+}
+
+#[cfg(not(windows))]
+impl<T: AsFd> AsFd for &mut T {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        T::as_fd(self)
+    }
+}
+
+#[cfg(windows)]
+impl<T: AsHandle> AsHandle for &T {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        T::as_handle(self)
+    }
+}
+
+#[cfg(windows)]
+impl<T: AsHandle> AsHandle for &mut T {
+    #[inline]
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        T::as_handle(self)
+    }
+}
+
+#[cfg(windows)]
+impl<T: AsSocket> AsSocket for &T {
+    #[inline]
+    fn as_socket(&self) -> BorrowedSocket<'_> {
+        T::as_socket(self)
+    }
+}
+
+#[cfg(windows)]
+impl<T: AsSocket> AsSocket for &mut T {
+    #[inline]
+    fn as_socket(&self) -> BorrowedSocket<'_> {
+        T::as_socket(self)
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -219,7 +219,8 @@ pub trait FromSocket {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(not(io_lifetimes_use_std))]
+#[cfg(any(unix, target_os = "wasi"))]
 impl<T: AsFd> AsFd for &T {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -227,7 +228,8 @@ impl<T: AsFd> AsFd for &T {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(not(io_lifetimes_use_std))]
+#[cfg(any(unix, target_os = "wasi"))]
 impl<T: AsFd> AsFd for &mut T {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -235,6 +237,7 @@ impl<T: AsFd> AsFd for &mut T {
     }
 }
 
+#[cfg(not(io_lifetimes_use_std))]
 #[cfg(windows)]
 impl<T: AsHandle> AsHandle for &T {
     #[inline]
@@ -243,6 +246,7 @@ impl<T: AsHandle> AsHandle for &T {
     }
 }
 
+#[cfg(not(io_lifetimes_use_std))]
 #[cfg(windows)]
 impl<T: AsHandle> AsHandle for &mut T {
     #[inline]
@@ -251,6 +255,7 @@ impl<T: AsHandle> AsHandle for &mut T {
     }
 }
 
+#[cfg(not(io_lifetimes_use_std))]
 #[cfg(windows)]
 impl<T: AsSocket> AsSocket for &T {
     #[inline]
@@ -259,6 +264,7 @@ impl<T: AsSocket> AsSocket for &T {
     }
 }
 
+#[cfg(not(io_lifetimes_use_std))]
 #[cfg(windows)]
 impl<T: AsSocket> AsSocket for &mut T {
     #[inline]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -11,7 +11,7 @@ use io_lifetimes::{
 
 struct Tester {}
 impl Tester {
-    fn use_file<Filelike: AsFilelike>(filelike: &Filelike) {
+    fn use_file<Filelike: AsFilelike>(filelike: Filelike) {
         let filelike = filelike.as_filelike();
         let _ = filelike.as_filelike_view::<std::fs::File>();
         let _ = unsafe {
@@ -24,7 +24,7 @@ impl Tester {
         let _ = dbg!(filelike);
     }
 
-    fn use_socket<Socketlike: AsSocketlike>(socketlike: &Socketlike) {
+    fn use_socket<Socketlike: AsSocketlike>(socketlike: Socketlike) {
         let socketlike = socketlike.as_socketlike();
         let _ = socketlike.as_socketlike_view::<std::net::TcpStream>();
         let _ = unsafe {
@@ -64,16 +64,16 @@ impl Tester {
 fn test_api() {
     let file = std::fs::File::open("Cargo.toml").unwrap();
     Tester::use_file(&file);
-    Tester::use_file(&file.as_filelike());
+    Tester::use_file(file.as_filelike());
     Tester::use_file(&*file.as_filelike_view::<std::fs::File>());
-    Tester::use_file(&file.as_filelike_view::<std::fs::File>().as_filelike());
+    Tester::use_file(file.as_filelike_view::<std::fs::File>().as_filelike());
 
     let socket = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     Tester::use_socket(&socket);
-    Tester::use_socket(&socket.as_socketlike());
+    Tester::use_socket(socket.as_socketlike());
     Tester::use_socket(&*socket.as_socketlike_view::<std::net::TcpListener>());
     Tester::use_socket(
-        &socket
+        socket
             .as_socketlike_view::<std::net::TcpListener>()
             .as_socketlike(),
     );


### PR DESCRIPTION
This ports rust-lang/rust#93888 to io-lifetimes.
