### PR TITLE
Fix compilation on wasm32-wasi.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,3 +76,26 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - run: cargo test --workspace --all-features
     - run: cargo test --workspace --no-default-features
+
+  check_nightly:
+    name: Check on Rust nightly
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [nightly]
+        include:
+          - build: nightly
+            os: ubuntu-latest
+            rust: nightly
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
+    - run: >
+        rustup target add
+        wasm32-wasi
+    - run: cargo check --workspace --release -vv --target=wasm32-wasi

--- a/src/types.rs
+++ b/src/types.rs
@@ -137,24 +137,33 @@ impl OwnedFd {
     pub fn try_clone(&self) -> std::io::Result<Self> {
         #[cfg(feature = "close")]
         {
-            // We want to atomically duplicate this file descriptor and set the
-            // CLOEXEC flag, and currently that's done via F_DUPFD_CLOEXEC. This
-            // is a POSIX flag that was added to Linux in 2.6.24.
-            #[cfg(not(target_os = "espidf"))]
-            let cmd = libc::F_DUPFD_CLOEXEC;
+            #[cfg(unix)]
+            {
+                // We want to atomically duplicate this file descriptor and set the
+                // CLOEXEC flag, and currently that's done via F_DUPFD_CLOEXEC. This
+                // is a POSIX flag that was added to Linux in 2.6.24.
+                #[cfg(not(target_os = "espidf"))]
+                let cmd = libc::F_DUPFD_CLOEXEC;
 
-            // For ESP-IDF, F_DUPFD is used instead, because the CLOEXEC semantics
-            // will never be supported, as this is a bare metal framework with
-            // no capabilities for multi-process execution.  While F_DUPFD is also
-            // not supported yet, it might be (currently it returns ENOSYS).
-            #[cfg(target_os = "espidf")]
-            let cmd = libc::F_DUPFD;
+                // For ESP-IDF, F_DUPFD is used instead, because the CLOEXEC semantics
+                // will never be supported, as this is a bare metal framework with
+                // no capabilities for multi-process execution.  While F_DUPFD is also
+                // not supported yet, it might be (currently it returns ENOSYS).
+                #[cfg(target_os = "espidf")]
+                let cmd = libc::F_DUPFD;
 
-            let fd = match unsafe { libc::fcntl(self.as_raw_fd(), cmd, 0) } {
-                -1 => return Err(std::io::Error::last_os_error()),
-                fd => fd,
-            };
-            Ok(unsafe { Self::from_raw_fd(fd) })
+                let fd = match unsafe { libc::fcntl(self.as_raw_fd(), cmd, 0) } {
+                    -1 => return Err(std::io::Error::last_os_error()),
+                    fd => fd,
+                };
+
+                Ok(unsafe { Self::from_raw_fd(fd) })
+            }
+
+            #[cfg(target_os = "wasi")]
+            {
+                unreachable!("try_clone is not yet suppported on wasi");
+            }
         }
 
         // If the `close` feature is disabled, we expect users to avoid cloning


### PR DESCRIPTION
WASI doesn't yet have `F_DUPFD_CLOEXEC`, so mark `try_clone` as
unsupported on wasm32-wasi for now.

And, add a CI check for WASI.