### PR TITLE
Mark `OwnedHandle` as `repr(transparent)`.

### DIFF
--- a/src/example_ffi.rs
+++ b/src/example_ffi.rs
@@ -21,7 +21,7 @@ use winapi::{
     um::minwinbase::{LPOVERLAPPED, LPSECURITY_ATTRIBUTES},
 };
 
-/// Declare a few FFI functions ourselves, to show off the FFI ergonomics.
+// Declare a few FFI functions ourselves, to show off the FFI ergonomics.
 #[cfg(all(rustc_attrs, any(unix, target_os = "wasi")))]
 extern "C" {
     pub fn open(pathname: *const c_char, flags: c_int, ...) -> Option<OwnedFd>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -206,6 +206,7 @@ impl OwnedFd {
 ///
 /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
 #[cfg(windows)]
+#[repr(transparent)]
 pub struct OwnedHandle {
     handle: RawHandle,
 }


### PR DESCRIPTION
This corresponds to rust-lang/rust#94572, which was recently approved.

Also, fix a warning about a doc comment on an extern block.