### PR TITLE
Make views require dedicated `unsafe` marker traits.

### DIFF
--- a/src/impls_async_std.rs
+++ b/src/impls_async_std.rs
@@ -2,6 +2,7 @@
 //! future, we'll prefer to have crates provide their own impls; this is
 //! just a temporary measure.
 
+use crate::views::{FilelikeViewType, SocketlikeViewType};
 #[cfg(any(unix, target_os = "wasi"))]
 use crate::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
@@ -17,6 +18,8 @@ use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::windows::io::{
     AsRawHandle, AsRawSocket, FromRawHandle, FromRawSocket, IntoRawHandle, IntoRawSocket,
 };
+
+unsafe impl FilelikeViewType for async_std::fs::File {}
 
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for async_std::fs::File {
@@ -66,6 +69,8 @@ impl FromHandle for async_std::fs::File {
     }
 }
 
+unsafe impl SocketlikeViewType for async_std::net::TcpStream {}
+
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for async_std::net::TcpStream {
     #[inline]
@@ -114,6 +119,8 @@ impl FromSocket for async_std::net::TcpStream {
     }
 }
 
+unsafe impl SocketlikeViewType for async_std::net::TcpListener {}
+
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for async_std::net::TcpListener {
     #[inline]
@@ -161,6 +168,8 @@ impl FromSocket for async_std::net::TcpListener {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
+
+unsafe impl SocketlikeViewType for async_std::net::UdpSocket {}
 
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for async_std::net::UdpSocket {
@@ -259,6 +268,9 @@ impl AsHandle for async_std::io::Stderr {
 }
 
 #[cfg(unix)]
+unsafe impl SocketlikeViewType for async_std::os::unix::net::UnixStream {}
+
+#[cfg(unix)]
 impl AsFd for async_std::os::unix::net::UnixStream {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -283,6 +295,9 @@ impl FromFd for async_std::os::unix::net::UnixStream {
 }
 
 #[cfg(unix)]
+unsafe impl SocketlikeViewType for async_std::os::unix::net::UnixListener {}
+
+#[cfg(unix)]
 impl AsFd for async_std::os::unix::net::UnixListener {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -305,6 +320,9 @@ impl FromFd for async_std::os::unix::net::UnixListener {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
+
+#[cfg(unix)]
+unsafe impl SocketlikeViewType for async_std::os::unix::net::UnixDatagram {}
 
 #[cfg(unix)]
 impl AsFd for async_std::os::unix::net::UnixDatagram {

--- a/src/impls_mio.rs
+++ b/src/impls_mio.rs
@@ -2,6 +2,9 @@
 //! future, we'll prefer to have crates provide their own impls; this is
 //! just a temporary measure.
 
+#[cfg(unix)]
+use crate::views::FilelikeViewType;
+use crate::views::SocketlikeViewType;
 #[cfg(any(unix, target_os = "wasi"))]
 use crate::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
@@ -12,6 +15,8 @@ use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket};
+
+unsafe impl SocketlikeViewType for mio::net::TcpStream {}
 
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for mio::net::TcpStream {
@@ -61,6 +66,8 @@ impl FromSocket for mio::net::TcpStream {
     }
 }
 
+unsafe impl SocketlikeViewType for mio::net::TcpListener {}
+
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for mio::net::TcpListener {
     #[inline]
@@ -108,6 +115,8 @@ impl FromSocket for mio::net::TcpListener {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
+
+unsafe impl SocketlikeViewType for mio::net::UdpSocket {}
 
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for mio::net::UdpSocket {
@@ -158,6 +167,9 @@ impl FromSocket for mio::net::UdpSocket {
 }
 
 #[cfg(unix)]
+unsafe impl SocketlikeViewType for mio::net::UnixDatagram {}
+
+#[cfg(unix)]
 impl AsFd for mio::net::UnixDatagram {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -180,6 +192,9 @@ impl FromFd for mio::net::UnixDatagram {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
+
+#[cfg(unix)]
+unsafe impl SocketlikeViewType for mio::net::UnixListener {}
 
 #[cfg(unix)]
 impl AsFd for mio::net::UnixListener {
@@ -206,6 +221,9 @@ impl FromFd for mio::net::UnixListener {
 }
 
 #[cfg(unix)]
+unsafe impl SocketlikeViewType for mio::net::UnixStream {}
+
+#[cfg(unix)]
 impl AsFd for mio::net::UnixStream {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -230,6 +248,9 @@ impl FromFd for mio::net::UnixStream {
 }
 
 #[cfg(unix)]
+unsafe impl FilelikeViewType for mio::unix::pipe::Receiver {}
+
+#[cfg(unix)]
 impl AsFd for mio::unix::pipe::Receiver {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -252,6 +273,9 @@ impl FromFd for mio::unix::pipe::Receiver {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
+
+#[cfg(unix)]
+unsafe impl FilelikeViewType for mio::unix::pipe::Sender {}
 
 #[cfg(unix)]
 impl AsFd for mio::unix::pipe::Sender {

--- a/src/impls_os_pipe.rs
+++ b/src/impls_os_pipe.rs
@@ -2,6 +2,7 @@
 //! future, we'll prefer to have crates provide their own impls; this is
 //! just a temporary measure.
 
+use crate::views::FilelikeViewType;
 #[cfg(any(unix, target_os = "wasi"))]
 use crate::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
@@ -12,6 +13,8 @@ use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
+
+unsafe impl FilelikeViewType for os_pipe::PipeReader {}
 
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for os_pipe::PipeReader {
@@ -60,6 +63,8 @@ impl FromHandle for os_pipe::PipeReader {
         unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
+
+unsafe impl FilelikeViewType for os_pipe::PipeWriter {}
 
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for os_pipe::PipeWriter {

--- a/src/impls_socket2.rs
+++ b/src/impls_socket2.rs
@@ -2,6 +2,7 @@
 //! future, we'll prefer to have crates provide their own impls; this is
 //! just a temporary measure.
 
+use crate::views::SocketlikeViewType;
 #[cfg(any(unix, target_os = "wasi"))]
 use crate::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
@@ -12,6 +13,8 @@ use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::os::wasi::io::{AsRawFd, FromRawFd, IntoRawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket};
+
+unsafe impl SocketlikeViewType for socket2::Socket {}
 
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for socket2::Socket {

--- a/src/impls_std.rs
+++ b/src/impls_std.rs
@@ -1,4 +1,3 @@
-use crate::views::{FilelikeViewType, SocketlikeViewType};
 #[cfg(any(unix, target_os = "wasi"))]
 use crate::{AsFd, FromFd, IntoFd};
 #[cfg(windows)]
@@ -41,9 +40,6 @@ impl AsSocket for BorrowedSocket<'_> {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
-unsafe impl FilelikeViewType for OwnedFd {}
-
-#[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for OwnedFd {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -52,18 +48,12 @@ impl AsFd for OwnedFd {
 }
 
 #[cfg(windows)]
-unsafe impl FilelikeViewType for OwnedHandle {}
-
-#[cfg(windows)]
 impl AsHandle for OwnedHandle {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
     }
 }
-
-#[cfg(windows)]
-unsafe impl SocketlikeViewType for OwnedSocket {}
 
 #[cfg(windows)]
 impl AsSocket for OwnedSocket {
@@ -129,8 +119,6 @@ impl FromHandle for HandleOrInvalid {
     }
 }
 
-unsafe impl FilelikeViewType for std::fs::File {}
-
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for std::fs::File {
     #[inline]
@@ -178,8 +166,6 @@ impl FromHandle for std::fs::File {
         unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
-
-unsafe impl SocketlikeViewType for std::net::TcpStream {}
 
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for std::net::TcpStream {
@@ -229,8 +215,6 @@ impl FromSocket for std::net::TcpStream {
     }
 }
 
-unsafe impl SocketlikeViewType for std::net::TcpListener {}
-
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for std::net::TcpListener {
     #[inline]
@@ -278,8 +262,6 @@ impl FromSocket for std::net::TcpListener {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
-
-unsafe impl SocketlikeViewType for std::net::UdpSocket {}
 
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for std::net::UdpSocket {
@@ -554,9 +536,6 @@ impl IntoHandle for std::process::Child {
 }
 
 #[cfg(unix)]
-unsafe impl SocketlikeViewType for std::os::unix::net::UnixStream {}
-
-#[cfg(unix)]
 impl AsFd for std::os::unix::net::UnixStream {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -581,9 +560,6 @@ impl FromFd for std::os::unix::net::UnixStream {
 }
 
 #[cfg(unix)]
-unsafe impl SocketlikeViewType for std::os::unix::net::UnixListener {}
-
-#[cfg(unix)]
 impl AsFd for std::os::unix::net::UnixListener {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -606,9 +582,6 @@ impl FromFd for std::os::unix::net::UnixListener {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
-
-#[cfg(unix)]
-unsafe impl SocketlikeViewType for std::os::unix::net::UnixDatagram {}
 
 #[cfg(unix)]
 impl AsFd for std::os::unix::net::UnixDatagram {

--- a/src/impls_std.rs
+++ b/src/impls_std.rs
@@ -1,3 +1,4 @@
+use crate::views::{FilelikeViewType, SocketlikeViewType};
 #[cfg(any(unix, target_os = "wasi"))]
 use crate::{AsFd, FromFd, IntoFd};
 #[cfg(windows)]
@@ -40,6 +41,9 @@ impl AsSocket for BorrowedSocket<'_> {
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
+unsafe impl FilelikeViewType for OwnedFd {}
+
+#[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for OwnedFd {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -48,12 +52,18 @@ impl AsFd for OwnedFd {
 }
 
 #[cfg(windows)]
+unsafe impl FilelikeViewType for OwnedHandle {}
+
+#[cfg(windows)]
 impl AsHandle for OwnedHandle {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
     }
 }
+
+#[cfg(windows)]
+unsafe impl SocketlikeViewType for OwnedSocket {}
 
 #[cfg(windows)]
 impl AsSocket for OwnedSocket {
@@ -119,6 +129,8 @@ impl FromHandle for HandleOrInvalid {
     }
 }
 
+unsafe impl FilelikeViewType for std::fs::File {}
+
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for std::fs::File {
     #[inline]
@@ -166,6 +178,8 @@ impl FromHandle for std::fs::File {
         unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
+
+unsafe impl SocketlikeViewType for std::net::TcpStream {}
 
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for std::net::TcpStream {
@@ -215,6 +229,8 @@ impl FromSocket for std::net::TcpStream {
     }
 }
 
+unsafe impl SocketlikeViewType for std::net::TcpListener {}
+
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for std::net::TcpListener {
     #[inline]
@@ -262,6 +278,8 @@ impl FromSocket for std::net::TcpListener {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
+
+unsafe impl SocketlikeViewType for std::net::UdpSocket {}
 
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for std::net::UdpSocket {
@@ -536,6 +554,9 @@ impl IntoHandle for std::process::Child {
 }
 
 #[cfg(unix)]
+unsafe impl SocketlikeViewType for std::os::unix::net::UnixStream {}
+
+#[cfg(unix)]
 impl AsFd for std::os::unix::net::UnixStream {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -560,6 +581,9 @@ impl FromFd for std::os::unix::net::UnixStream {
 }
 
 #[cfg(unix)]
+unsafe impl SocketlikeViewType for std::os::unix::net::UnixListener {}
+
+#[cfg(unix)]
 impl AsFd for std::os::unix::net::UnixListener {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -582,6 +606,9 @@ impl FromFd for std::os::unix::net::UnixListener {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
+
+#[cfg(unix)]
+unsafe impl SocketlikeViewType for std::os::unix::net::UnixDatagram {}
 
 #[cfg(unix)]
 impl AsFd for std::os::unix::net::UnixDatagram {

--- a/src/impls_std_views.rs
+++ b/src/impls_std_views.rs
@@ -1,6 +1,6 @@
 use crate::views::{FilelikeViewType, SocketlikeViewType};
 #[cfg(any(unix, target_os = "wasi"))]
-use crate::{OwnedFd};
+use crate::OwnedFd;
 #[cfg(windows)]
 use crate::{OwnedHandle, OwnedSocket};
 

--- a/src/impls_std_views.rs
+++ b/src/impls_std_views.rs
@@ -1,0 +1,31 @@
+use crate::views::{FilelikeViewType, SocketlikeViewType};
+#[cfg(any(unix, target_os = "wasi"))]
+use crate::{OwnedFd};
+#[cfg(windows)]
+use crate::{OwnedHandle, OwnedSocket};
+
+#[cfg(any(unix, target_os = "wasi"))]
+unsafe impl FilelikeViewType for OwnedFd {}
+
+#[cfg(windows)]
+unsafe impl FilelikeViewType for OwnedHandle {}
+
+#[cfg(windows)]
+unsafe impl SocketlikeViewType for OwnedSocket {}
+
+unsafe impl FilelikeViewType for std::fs::File {}
+
+unsafe impl SocketlikeViewType for std::net::TcpStream {}
+
+unsafe impl SocketlikeViewType for std::net::TcpListener {}
+
+unsafe impl SocketlikeViewType for std::net::UdpSocket {}
+
+#[cfg(unix)]
+unsafe impl SocketlikeViewType for std::os::unix::net::UnixStream {}
+
+#[cfg(unix)]
+unsafe impl SocketlikeViewType for std::os::unix::net::UnixListener {}
+
+#[cfg(unix)]
+unsafe impl SocketlikeViewType for std::os::unix::net::UnixDatagram {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod types;
 
 #[cfg(not(io_lifetimes_use_std))]
 mod impls_std;
+mod impls_std_views;
 
 #[cfg(not(io_lifetimes_use_std))]
 #[cfg(any(unix, target_os = "wasi"))]

--- a/src/portability.rs
+++ b/src/portability.rs
@@ -93,8 +93,17 @@ pub trait AsFilelike: AsFd {
     /// ```
     fn as_filelike(&self) -> BorrowedFilelike<'_>;
 
-    /// Return a borrowing view of a resource which dereferences to a `&Target`
-    /// or `&mut Target`.
+    /// Return a borrowing view of a resource which dereferences to a `&Target`.
+    ///
+    /// Note that [`Read`] or [`Write`] require `&mut Target`, but in some cases,
+    /// such as [`File`], `Read` and `Write` are implemented for `&Target` in
+    /// addition to `Target`, and you can get a `&mut &Target` by doing `&*` on
+    /// the resuting view, like this:
+    ///
+    /// ```rust,ignore
+    /// let v = f.as_filelike_view::<std::fs::File>();
+    /// (&*v).read(&mut buf).unwrap();
+    /// ```
     ///
     /// [`File`]: std::fs::File
     fn as_filelike_view<Target: FilelikeViewType>(&self) -> FilelikeView<'_, Target>;
@@ -135,8 +144,17 @@ pub trait AsFilelike: AsHandle {
     /// ```
     fn as_filelike(&self) -> BorrowedFilelike<'_>;
 
-    /// Return a borrowing view of a resource which dereferences to a `&Target`
-    /// or `&mut Target`.
+    /// Return a borrowing view of a resource which dereferences to a `&Target`.
+    ///
+    /// Note that [`Read`] or [`Write`] require `&mut Target`, but in some cases,
+    /// such as [`File`], `Read` and `Write` are implemented for `&Target` in
+    /// addition to `Target`, and you can get a `&mut &Target` by doing `&*` on
+    /// the resuting view, like this:
+    ///
+    /// ```rust,ignore
+    /// let v = f.as_filelike_view::<std::fs::File>();
+    /// (&*v).read(&mut buf).unwrap();
+    /// ```
     ///
     /// [`File`]: std::fs::File
     fn as_filelike_view<Target: FilelikeViewType>(&self) -> FilelikeView<'_, Target>;
@@ -166,8 +184,17 @@ pub trait AsSocketlike: AsFd {
     /// Borrows the reference.
     fn as_socketlike(&self) -> BorrowedSocketlike<'_>;
 
-    /// Return a borrowing view of a resource which dereferences to a `&Target`
-    /// or `&mut Target`.
+    /// Return a borrowing view of a resource which dereferences to a `&Target`.
+    ///
+    /// Note that [`Read`] or [`Write`] require `&mut Target`, but in some cases,
+    /// such as [`TcpStream`], `Read` and `Write` are implemented for `&Target` in
+    /// addition to `Target`, and you can get a `&mut &Target` by doing `&*` on
+    /// the resuting view, like this:
+    ///
+    /// ```rust,ignore
+    /// let v = s.as_socketlike_view::<std::net::TcpStream>();
+    /// (&*v).read(&mut buf).unwrap();
+    /// ```
     ///
     /// [`TcpStream`]: std::net::TcpStream
     fn as_socketlike_view<Target: SocketlikeViewType>(&self) -> SocketlikeView<'_, Target>;
@@ -197,8 +224,17 @@ pub trait AsSocketlike: AsSocket {
     /// Borrows the reference.
     fn as_socketlike(&self) -> BorrowedSocketlike;
 
-    /// Return a borrowing view of a resource which dereferences to a `&Target`
-    /// or `&mut Target`.
+    /// Return a borrowing view of a resource which dereferences to a `&Target`.
+    ///
+    /// Note that [`Read`] or [`Write`] require `&mut Target`, but in some cases,
+    /// such as [`TcpStream`], `Read` and `Write` are implemented for `&Target` in
+    /// addition to `Target`, and you can get a `&mut &Target` by doing `&*` on
+    /// the resuting view, like this:
+    ///
+    /// ```rust,ignore
+    /// let v = s.as_socketlike_view::<std::net::TcpStream>();
+    /// (&*v).read(&mut buf).unwrap();
+    /// ```
     ///
     /// [`TcpStream`]: std::net::TcpStream
     fn as_socketlike_view<Target: SocketlikeViewType>(&self) -> SocketlikeView<'_, Target>;

--- a/src/portability.rs
+++ b/src/portability.rs
@@ -6,7 +6,7 @@
 //!
 //! TODO: Should this layer be folded into types.rs/traits.rs?
 
-use crate::views::{FilelikeView, SocketlikeView};
+use crate::views::{FilelikeView, FilelikeViewType, SocketlikeView, SocketlikeViewType};
 #[cfg(any(unix, target_os = "wasi"))]
 use crate::{AsFd, BorrowedFd, FromFd, IntoFd, OwnedFd};
 #[cfg(windows)]
@@ -97,7 +97,7 @@ pub trait AsFilelike: AsFd {
     /// or `&mut Target`.
     ///
     /// [`File`]: std::fs::File
-    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(&self) -> FilelikeView<'_, Target>;
+    fn as_filelike_view<Target: FilelikeViewType>(&self) -> FilelikeView<'_, Target>;
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
@@ -108,7 +108,7 @@ impl<T: AsFd> AsFilelike for T {
     }
 
     #[inline]
-    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(&self) -> FilelikeView<'_, Target> {
+    fn as_filelike_view<Target: FilelikeViewType>(&self) -> FilelikeView<'_, Target> {
         FilelikeView::new(self)
     }
 }
@@ -139,7 +139,7 @@ pub trait AsFilelike: AsHandle {
     /// or `&mut Target`.
     ///
     /// [`File`]: std::fs::File
-    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(&self) -> FilelikeView<'_, Target>;
+    fn as_filelike_view<Target: FilelikeViewType>(&self) -> FilelikeView<'_, Target>;
 }
 
 #[cfg(windows)]
@@ -150,7 +150,7 @@ impl<T: AsHandle> AsFilelike for T {
     }
 
     #[inline]
-    fn as_filelike_view<Target: FromFilelike + IntoFilelike>(&self) -> FilelikeView<'_, Target> {
+    fn as_filelike_view<Target: FilelikeViewType>(&self) -> FilelikeView<'_, Target> {
         FilelikeView::new(self)
     }
 }
@@ -170,9 +170,7 @@ pub trait AsSocketlike: AsFd {
     /// or `&mut Target`.
     ///
     /// [`TcpStream`]: std::net::TcpStream
-    fn as_socketlike_view<Target: FromSocketlike + IntoSocketlike>(
-        &self,
-    ) -> SocketlikeView<'_, Target>;
+    fn as_socketlike_view<Target: SocketlikeViewType>(&self) -> SocketlikeView<'_, Target>;
 }
 
 #[cfg(any(unix, target_os = "wasi"))]
@@ -183,9 +181,7 @@ impl<T: AsFd> AsSocketlike for T {
     }
 
     #[inline]
-    fn as_socketlike_view<Target: FromSocketlike + IntoSocketlike>(
-        &self,
-    ) -> SocketlikeView<'_, Target> {
+    fn as_socketlike_view<Target: SocketlikeViewType>(&self) -> SocketlikeView<'_, Target> {
         SocketlikeView::new(self)
     }
 }
@@ -205,9 +201,7 @@ pub trait AsSocketlike: AsSocket {
     /// or `&mut Target`.
     ///
     /// [`TcpStream`]: std::net::TcpStream
-    fn as_socketlike_view<Target: FromSocketlike + IntoSocketlike>(
-        &self,
-    ) -> SocketlikeView<'_, Target>;
+    fn as_socketlike_view<Target: SocketlikeViewType>(&self) -> SocketlikeView<'_, Target>;
 }
 
 #[cfg(windows)]
@@ -218,9 +212,7 @@ impl<T: AsSocket> AsSocketlike for T {
     }
 
     #[inline]
-    fn as_socketlike_view<Target: FromSocketlike + IntoSocketlike>(
-        &self,
-    ) -> SocketlikeView<'_, Target> {
+    fn as_socketlike_view<Target: SocketlikeViewType>(&self) -> SocketlikeView<'_, Target> {
         SocketlikeView::new(self)
     }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -150,6 +150,14 @@ pub trait IntoRawSocketlike: IntoRawFd {
     fn into_raw_socketlike(self) -> RawSocketlike;
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl<T: IntoRawFd> IntoRawSocketlike for T {
+    #[inline]
+    fn into_raw_socketlike(self) -> RawSocketlike {
+        self.into_raw_fd()
+    }
+}
+
 /// This is a portability abstraction over Unix-like `IntoRawFd` and Windows'
 /// [`IntoRawSocket`].
 #[cfg(windows)]

--- a/src/views.rs
+++ b/src/views.rs
@@ -153,26 +153,30 @@ impl<Target: SocketlikeViewType> Deref for SocketlikeView<'_, Target> {
 impl<Target: FilelikeViewType> Drop for FilelikeView<'_, Target> {
     fn drop(&mut self) {
         // Use `Into*` to consume `self.target` without freeing its resource.
-        let raw = self
+        let _raw = self
             .target
             .take()
             .unwrap()
             .into_filelike()
             .into_raw_filelike();
-        debug_assert_eq!(self.orig, raw);
+
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(self.orig, _raw);
     }
 }
 
 impl<Target: SocketlikeViewType> Drop for SocketlikeView<'_, Target> {
     fn drop(&mut self) {
         // Use `Into*` to consume `self.target` without freeing its resource.
-        let raw = self
+        let _raw = self
             .target
             .take()
             .unwrap()
             .into_socketlike()
             .into_raw_socketlike();
-        debug_assert_eq!(self.orig, raw);
+
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(self.orig, _raw);
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use std::fmt;
 use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 
 /// Declare that a type is safe to use in a [`FilelikeView`].
 ///
@@ -137,20 +137,6 @@ impl<Target: SocketlikeViewType> Deref for SocketlikeView<'_, Target> {
     #[inline]
     fn deref(&self) -> &Self::Target {
         self.target.as_ref().unwrap()
-    }
-}
-
-impl<Target: FilelikeViewType> DerefMut for FilelikeView<'_, Target> {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.target.as_mut().unwrap()
-    }
-}
-
-impl<Target: SocketlikeViewType> DerefMut for SocketlikeView<'_, Target> {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.target.as_mut().unwrap()
     }
 }
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -8,45 +8,75 @@ use io_lifetimes::{
     AsFilelike, AsSocketlike, BorrowedFilelike, FromFilelike, FromSocketlike, IntoFilelike,
     IntoSocketlike,
 };
+use std::io::{Read, Write};
 
 struct Tester {}
 impl Tester {
     fn use_file<Filelike: AsFilelike>(filelike: Filelike) {
+        let mut buf = Vec::new();
+
         let filelike = filelike.as_filelike();
-        let _ = filelike.as_filelike_view::<std::fs::File>();
-        let _ = unsafe {
+
+        let view = filelike.as_filelike_view::<std::fs::File>();
+        let _ = (&*view).read(&mut buf).is_ok();
+        let _ = (&*view).write(&buf).is_ok();
+
+        let view = unsafe {
             FilelikeView::<std::fs::File>::view_raw(
                 filelike
                     .as_filelike_view::<std::fs::File>()
                     .as_raw_filelike(),
             )
         };
+        let _ = (&*view).read(&mut buf).is_ok();
+        let _ = (&*view).write(&buf).is_ok();
+
         let _ = dbg!(filelike);
     }
 
     fn use_socket<Socketlike: AsSocketlike>(socketlike: Socketlike) {
+        let mut buf = Vec::new();
+
         let socketlike = socketlike.as_socketlike();
-        let _ = socketlike.as_socketlike_view::<std::net::TcpStream>();
-        let _ = unsafe {
+        let view = socketlike.as_socketlike_view::<std::net::TcpStream>();
+        let _ = (&*view).read(&mut buf).is_ok();
+        let _ = (&*view).write(&buf).is_ok();
+
+        let view = unsafe {
             SocketlikeView::<std::net::TcpStream>::view_raw(
                 socketlike
                     .as_socketlike_view::<std::net::TcpStream>()
                     .as_raw_socketlike(),
             )
         };
+        let _ = (&*view).read(&mut buf).is_ok();
+        let _ = (&*view).write(&buf).is_ok();
+
         let _ = dbg!(socketlike);
     }
 
     fn from_file<Filelike: IntoFilelike>(filelike: Filelike) {
+        let mut buf = Vec::new();
+
         let filelike = filelike.into_filelike();
-        let _ = filelike.as_filelike_view::<std::fs::File>();
+        let view = filelike.as_filelike_view::<std::fs::File>();
+        let _ = (&*view).read(&mut buf).is_ok();
+        let _ = (&*view).write(&buf).is_ok();
+        drop(view);
+
         let _ = dbg!(&filelike);
         let _ = std::fs::File::from_filelike(filelike);
     }
 
     fn from_socket<Socketlike: IntoSocketlike>(socketlike: Socketlike) {
+        let mut buf = Vec::new();
+
         let socketlike = socketlike.into_socketlike();
-        let _ = socketlike.as_socketlike_view::<std::net::TcpStream>();
+        let view = socketlike.as_socketlike_view::<std::net::TcpStream>();
+        let _ = (&*view).read(&mut buf).is_ok();
+        let _ = (&*view).write(&buf).is_ok();
+        drop(view);
+
         let _ = dbg!(&socketlike);
         let _ = std::net::TcpStream::from_socketlike(socketlike);
     }


### PR DESCRIPTION
Requiring `Into` and `From` conversions is not sufficient for
`FilelikeView` and `SocketlikeView`, becuase there's no guarantee
that the `Into` implementation will return the same handle as the `From`
implementation. If a type allows its handle to be reassigned, that
can lead to the old handle being freed twice, and the new handle being
leaked.

To fix this, introduce unsafe marker traits `FilelikeViewType` and
`SocketlikeViewType`, and have `FilelikeView` and `SocketlikeView`
require these traits.