### PR TITLE
Add `From<OwnedFd>` and `From<T> for OwnedFd` impls.

### DIFF
--- a/examples/owning-wrapper.rs
+++ b/examples/owning-wrapper.rs
@@ -83,6 +83,7 @@ impl IntoHandle for Thing {
     }
 }
 
+#[cfg(not(io_lifetimes_use_std))]
 #[cfg(windows)]
 impl From<Thing> for OwnedHandle {
     #[inline]
@@ -99,6 +100,7 @@ impl FromHandle for Thing {
     }
 }
 
+#[cfg(not(io_lifetimes_use_std))]
 #[cfg(windows)]
 impl From<OwnedHandle> for Thing {
     #[inline]

--- a/examples/owning-wrapper.rs
+++ b/examples/owning-wrapper.rs
@@ -104,8 +104,8 @@ impl FromHandle for Thing {
 #[cfg(windows)]
 impl From<OwnedHandle> for Thing {
     #[inline]
-    fn from(owned: Thing) -> Self {
-        Self { filelike: owned }
+    fn from(filelike: OwnedHandle) -> Self {
+        Self { filelike }
     }
 }
 

--- a/examples/owning-wrapper.rs
+++ b/examples/owning-wrapper.rs
@@ -41,10 +41,28 @@ impl IntoFd for Thing {
     }
 }
 
+#[cfg(not(io_lifetimes_use_std))]
+#[cfg(not(windows))]
+impl From<Thing> for OwnedFd {
+    #[inline]
+    fn from(owned: Thing) -> Self {
+        owned.filelike
+    }
+}
+
 #[cfg(not(windows))]
 impl FromFd for Thing {
     #[inline]
     fn from_fd(filelike: OwnedFd) -> Self {
+        Self { filelike }
+    }
+}
+
+#[cfg(not(io_lifetimes_use_std))]
+#[cfg(not(windows))]
+impl From<OwnedFd> for Thing {
+    #[inline]
+    fn from(filelike: OwnedFd) -> Self {
         Self { filelike }
     }
 }
@@ -66,10 +84,26 @@ impl IntoHandle for Thing {
 }
 
 #[cfg(windows)]
+impl From<Thing> for OwnedHandle {
+    #[inline]
+    fn from(owned: Thing) -> Self {
+        owned.filelike
+    }
+}
+
+#[cfg(windows)]
 impl FromHandle for Thing {
     #[inline]
     fn from_handle(filelike: OwnedHandle) -> Self {
         Self { filelike }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedHandle> for Thing {
+    #[inline]
+    fn from(owned: Thing) -> Self {
+        Self { filelike: owned }
     }
 }
 

--- a/src/impls_async_std.rs
+++ b/src/impls_async_std.rs
@@ -45,11 +45,27 @@ impl IntoFd for async_std::fs::File {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<async_std::fs::File> for OwnedFd {
+    #[inline]
+    fn from(owned: async_std::fs::File) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoHandle for async_std::fs::File {
     #[inline]
     fn into_handle(self) -> OwnedHandle {
         unsafe { OwnedHandle::from_raw_handle(self.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<async_std::fs::File> for OwnedHandle {
+    #[inline]
+    fn from(owned: async_std::fs::File) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
 
@@ -61,10 +77,26 @@ impl FromFd for async_std::fs::File {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for async_std::fs::File {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromHandle for async_std::fs::File {
     #[inline]
     fn from_handle(owned: OwnedHandle) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedHandle> for async_std::fs::File {
+    #[inline]
+    fn from(owned: OwnedHandle) -> Self {
         unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
@@ -95,11 +127,27 @@ impl IntoFd for async_std::net::TcpStream {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<async_std::net::TcpStream> for OwnedFd {
+    #[inline]
+    fn from(owned: async_std::net::TcpStream) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoSocket for async_std::net::TcpStream {
     #[inline]
     fn into_socket(self) -> OwnedSocket {
         unsafe { OwnedSocket::from_raw_socket(self.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<async_std::net::TcpStream> for OwnedSocket {
+    #[inline]
+    fn from(owned: async_std::net::TcpStream) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
 
@@ -111,10 +159,26 @@ impl FromFd for async_std::net::TcpStream {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for async_std::net::TcpStream {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromSocket for async_std::net::TcpStream {
     #[inline]
     fn from_socket(owned: OwnedSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedSocket> for async_std::net::TcpStream {
+    #[inline]
+    fn from(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
@@ -145,11 +209,27 @@ impl IntoFd for async_std::net::TcpListener {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<async_std::net::TcpListener> for OwnedFd {
+    #[inline]
+    fn from(owned: async_std::net::TcpListener) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoSocket for async_std::net::TcpListener {
     #[inline]
     fn into_socket(self) -> OwnedSocket {
         unsafe { OwnedSocket::from_raw_socket(self.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<async_std::net::TcpListener> for OwnedSocket {
+    #[inline]
+    fn from(owned: async_std::net::TcpListener) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
 
@@ -161,10 +241,26 @@ impl FromFd for async_std::net::TcpListener {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for async_std::net::TcpListener {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromSocket for async_std::net::TcpListener {
     #[inline]
     fn from_socket(owned: OwnedSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedSocket> for async_std::net::TcpListener {
+    #[inline]
+    fn from(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
@@ -195,11 +291,27 @@ impl IntoFd for async_std::net::UdpSocket {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<async_std::net::UdpSocket> for OwnedFd {
+    #[inline]
+    fn from(owned: async_std::net::UdpSocket) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoSocket for async_std::net::UdpSocket {
     #[inline]
     fn into_socket(self) -> OwnedSocket {
         unsafe { OwnedSocket::from_raw_socket(self.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<async_std::net::UdpSocket> for OwnedSocket {
+    #[inline]
+    fn from(owned: async_std::net::UdpSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
 
@@ -211,10 +323,26 @@ impl FromFd for async_std::net::UdpSocket {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for async_std::net::UdpSocket {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromSocket for async_std::net::UdpSocket {
     #[inline]
     fn from_socket(owned: OwnedSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedSocket> for async_std::net::UdpSocket {
+    #[inline]
+    fn from(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
@@ -287,9 +415,25 @@ impl IntoFd for async_std::os::unix::net::UnixStream {
 }
 
 #[cfg(unix)]
+impl From<async_std::os::unix::net::UnixStream> for OwnedFd {
+    #[inline]
+    fn from(owned: async_std::os::unix::net::UnixStream) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
 impl FromFd for async_std::os::unix::net::UnixStream {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
+impl From<OwnedFd> for async_std::os::unix::net::UnixStream {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
@@ -314,9 +458,25 @@ impl IntoFd for async_std::os::unix::net::UnixListener {
 }
 
 #[cfg(unix)]
+impl From<async_std::os::unix::net::UnixListener> for OwnedFd {
+    #[inline]
+    fn from(owned: async_std::os::unix::net::UnixListener) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
 impl FromFd for async_std::os::unix::net::UnixListener {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
+impl From<OwnedFd> for async_std::os::unix::net::UnixListener {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
@@ -341,9 +501,25 @@ impl IntoFd for async_std::os::unix::net::UnixDatagram {
 }
 
 #[cfg(unix)]
+impl From<async_std::os::unix::net::UnixDatagram> for OwnedFd {
+    #[inline]
+    fn from(owned: async_std::os::unix::net::UnixDatagram) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
 impl FromFd for async_std::os::unix::net::UnixDatagram {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
+impl From<OwnedFd> for async_std::os::unix::net::UnixDatagram {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }

--- a/src/impls_fs_err.rs
+++ b/src/impls_fs_err.rs
@@ -37,10 +37,26 @@ impl IntoFd for fs_err::File {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<fs_err::File> for OwnedFd {
+    #[inline]
+    fn from(owned: fs_err::File) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoHandle for fs_err::File {
     #[inline]
     fn into_handle(self) -> OwnedHandle {
         unsafe { OwnedHandle::from_raw_handle(self.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<fs_err::File> for OwnedHandle {
+    #[inline]
+    fn from(owned: fs_err::File) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }

--- a/src/impls_mio.rs
+++ b/src/impls_mio.rs
@@ -42,11 +42,27 @@ impl IntoFd for mio::net::TcpStream {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<mio::net::TcpStream> for OwnedFd {
+    #[inline]
+    fn from(owned: mio::net::TcpStream) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoSocket for mio::net::TcpStream {
     #[inline]
     fn into_socket(self) -> OwnedSocket {
         unsafe { OwnedSocket::from_raw_socket(self.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<mio::net::TcpStream> for OwnedSocket {
+    #[inline]
+    fn from(owned: mio::net::TcpStream) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
 
@@ -58,10 +74,26 @@ impl FromFd for mio::net::TcpStream {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for mio::net::TcpStream {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromSocket for mio::net::TcpStream {
     #[inline]
     fn from_socket(owned: OwnedSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedSocket> for mio::net::TcpStream {
+    #[inline]
+    fn from(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
@@ -92,11 +124,27 @@ impl IntoFd for mio::net::TcpListener {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<mio::net::TcpListener> for OwnedFd {
+    #[inline]
+    fn from(owned: mio::net::TcpListener) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoSocket for mio::net::TcpListener {
     #[inline]
     fn into_socket(self) -> OwnedSocket {
         unsafe { OwnedSocket::from_raw_socket(self.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<mio::net::TcpListener> for OwnedSocket {
+    #[inline]
+    fn from(owned: mio::net::TcpListener) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
 
@@ -108,10 +156,26 @@ impl FromFd for mio::net::TcpListener {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for mio::net::TcpListener {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromSocket for mio::net::TcpListener {
     #[inline]
     fn from_socket(owned: OwnedSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedSocket> for mio::net::TcpListener {
+    #[inline]
+    fn from(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
@@ -142,11 +206,27 @@ impl IntoFd for mio::net::UdpSocket {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<mio::net::UdpSocket> for OwnedFd {
+    #[inline]
+    fn from(owned: mio::net::UdpSocket) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoSocket for mio::net::UdpSocket {
     #[inline]
     fn into_socket(self) -> OwnedSocket {
         unsafe { OwnedSocket::from_raw_socket(self.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<mio::net::UdpSocket> for OwnedSocket {
+    #[inline]
+    fn from(owned: mio::net::UdpSocket) -> Self {
+        unsafe { Self::from_raw_socket(listener.into_raw_socket()) }
     }
 }
 
@@ -158,10 +238,26 @@ impl FromFd for mio::net::UdpSocket {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for mio::net::UdpSocket {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromSocket for mio::net::UdpSocket {
     #[inline]
     fn from_socket(owned: OwnedSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedSocket> for mio::net::UdpSocket {
+    #[inline]
+    fn from(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
@@ -186,9 +282,25 @@ impl IntoFd for mio::net::UnixDatagram {
 }
 
 #[cfg(unix)]
+impl From<mio::net::UnixDatagram> for OwnedFd {
+    #[inline]
+    fn from(owned: mio::net::UnixDatagram) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
 impl FromFd for mio::net::UnixDatagram {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
+impl From<OwnedFd> for mio::net::UnixDatagram {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
@@ -213,9 +325,25 @@ impl IntoFd for mio::net::UnixListener {
 }
 
 #[cfg(unix)]
+impl From<mio::net::UnixListener> for OwnedFd {
+    #[inline]
+    fn from(owned: mio::net::UnixListener) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
 impl FromFd for mio::net::UnixListener {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
+impl From<OwnedFd> for mio::net::UnixListener {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
@@ -240,9 +368,25 @@ impl IntoFd for mio::net::UnixStream {
 }
 
 #[cfg(unix)]
+impl From<mio::net::UnixStream> for OwnedFd {
+    #[inline]
+    fn from(owned: mio::net::UnixStream) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
 impl FromFd for mio::net::UnixStream {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
+impl From<OwnedFd> for mio::net::UnixStream {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
@@ -267,9 +411,25 @@ impl IntoFd for mio::unix::pipe::Receiver {
 }
 
 #[cfg(unix)]
+impl From<mio::unix::pipe::Receiver> for OwnedFd {
+    #[inline]
+    fn from(owned: mio::unix::pipe::Receiver) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
 impl FromFd for mio::unix::pipe::Receiver {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
+impl From<OwnedFd> for mio::unix::pipe::Receiver {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
@@ -294,9 +454,25 @@ impl IntoFd for mio::unix::pipe::Sender {
 }
 
 #[cfg(unix)]
+impl From<mio::unix::pipe::Sender> for OwnedFd {
+    #[inline]
+    fn from(owned: mio::unix::pipe::Sender) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
 impl FromFd for mio::unix::pipe::Sender {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
+impl From<OwnedFd> for mio::unix::pipe::Sender {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }

--- a/src/impls_mio.rs
+++ b/src/impls_mio.rs
@@ -226,7 +226,7 @@ impl IntoSocket for mio::net::UdpSocket {
 impl From<mio::net::UdpSocket> for OwnedSocket {
     #[inline]
     fn from(owned: mio::net::UdpSocket) -> Self {
-        unsafe { Self::from_raw_socket(listener.into_raw_socket()) }
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
 

--- a/src/impls_os_pipe.rs
+++ b/src/impls_os_pipe.rs
@@ -139,7 +139,7 @@ impl IntoHandle for os_pipe::PipeWriter {
 }
 
 #[cfg(windows)]
-impl From<os_pipe::PipeWriter> for OwnedFd {
+impl From<os_pipe::PipeWriter> for OwnedHandle {
     #[inline]
     fn from(owned: os_pipe::PipeWriter) -> Self {
         unsafe { Self::from_raw_handle(owned.into_raw_handle()) }

--- a/src/impls_os_pipe.rs
+++ b/src/impls_os_pipe.rs
@@ -40,11 +40,27 @@ impl IntoFd for os_pipe::PipeReader {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<os_pipe::PipeReader> for OwnedFd {
+    #[inline]
+    fn from(owned: os_pipe::PipeReader) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoHandle for os_pipe::PipeReader {
     #[inline]
     fn into_handle(self) -> OwnedHandle {
         unsafe { OwnedHandle::from_raw_handle(self.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<os_pipe::PipeReader> for OwnedHandle {
+    #[inline]
+    fn from(owned: os_pipe::PipeReader) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
 
@@ -56,10 +72,26 @@ impl FromFd for os_pipe::PipeReader {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for os_pipe::PipeReader {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromHandle for os_pipe::PipeReader {
     #[inline]
     fn from_handle(owned: OwnedHandle) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedHandle> for os_pipe::PipeReader {
+    #[inline]
+    fn from(owned: OwnedHandle) -> Self {
         unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
@@ -90,11 +122,27 @@ impl IntoFd for os_pipe::PipeWriter {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<os_pipe::PipeWriter> for OwnedFd {
+    #[inline]
+    fn from(owned: os_pipe::PipeWriter) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoHandle for os_pipe::PipeWriter {
     #[inline]
     fn into_handle(self) -> OwnedHandle {
         unsafe { OwnedHandle::from_raw_handle(self.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<os_pipe::PipeWriter> for OwnedFd {
+    #[inline]
+    fn from(owned: os_pipe::PipeWriter) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
 
@@ -106,10 +154,26 @@ impl FromFd for os_pipe::PipeWriter {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for os_pipe::PipeWriter {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromHandle for os_pipe::PipeWriter {
     #[inline]
     fn from_handle(owned: OwnedHandle) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedHandle> for os_pipe::PipeWriter {
+    #[inline]
+    fn from(owned: OwnedHandle) -> Self {
         unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }

--- a/src/impls_socket2.rs
+++ b/src/impls_socket2.rs
@@ -40,11 +40,27 @@ impl IntoFd for socket2::Socket {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<socket2::Socket> for OwnedFd {
+    #[inline]
+    fn from(owned: socket2::Socket) -> Self {
+        unsafe { OwnedFd::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoSocket for socket2::Socket {
     #[inline]
     fn into_socket(self) -> OwnedSocket {
         unsafe { OwnedSocket::from_raw_socket(self.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<socket2::Socket> for OwnedSocket {
+    #[inline]
+    fn from(owned: socket2::Socket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
 
@@ -56,10 +72,26 @@ impl FromFd for socket2::Socket {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for socket2::Socket {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromSocket for socket2::Socket {
     #[inline]
     fn from_socket(owned: OwnedSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedSocket> for socket2::Socket {
+    #[inline]
+    fn from(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }

--- a/src/impls_std.rs
+++ b/src/impls_std.rs
@@ -119,6 +119,14 @@ impl FromHandle for HandleOrInvalid {
     }
 }
 
+#[cfg(windows)]
+impl From<OwnedHandle> for HandleOrInvalid {
+    #[inline]
+    fn from(owned: OwnedHandle) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
+    }
+}
+
 #[cfg(any(unix, target_os = "wasi"))]
 impl AsFd for std::fs::File {
     #[inline]
@@ -143,11 +151,27 @@ impl IntoFd for std::fs::File {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<std::fs::File> for OwnedFd {
+    #[inline]
+    fn from(owned: std::fs::File) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoHandle for std::fs::File {
     #[inline]
     fn into_handle(self) -> OwnedHandle {
         unsafe { OwnedHandle::from_raw_handle(self.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<std::fs::File> for OwnedHandle {
+    #[inline]
+    fn from(owned: std::fs::File) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
 
@@ -159,10 +183,26 @@ impl FromFd for std::fs::File {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for std::fs::File {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromHandle for std::fs::File {
     #[inline]
     fn from_handle(owned: OwnedHandle) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedHandle> for std::fs::File {
+    #[inline]
+    fn from(owned: OwnedHandle) -> Self {
         unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
@@ -191,11 +231,27 @@ impl IntoFd for std::net::TcpStream {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<std::net::TcpStream> for OwnedFd {
+    #[inline]
+    fn from(owned: std::net::TcpStream) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoSocket for std::net::TcpStream {
     #[inline]
     fn into_socket(self) -> OwnedSocket {
         unsafe { OwnedSocket::from_raw_socket(self.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<std::net::TcpStream> for OwnedSocket {
+    #[inline]
+    fn from(owned: std::net::TcpStream) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
 
@@ -207,8 +263,24 @@ impl FromFd for std::net::TcpStream {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for std::net::TcpStream {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromSocket for std::net::TcpStream {
+    #[inline]
+    fn from_socket(owned: OwnedSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedSocket> for std::net::TcpStream {
     #[inline]
     fn from_socket(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
@@ -239,11 +311,27 @@ impl IntoFd for std::net::TcpListener {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<std::net::TcpListener> for OwnedFd {
+    #[inline]
+    fn from(owned: std::net::TcpListener) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoSocket for std::net::TcpListener {
     #[inline]
     fn into_socket(self) -> OwnedSocket {
         unsafe { OwnedSocket::from_raw_socket(self.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<std::net::TcpListener> for OwnedSocket {
+    #[inline]
+    fn from(owned: std::net::TcpListener) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
 
@@ -255,8 +343,24 @@ impl FromFd for std::net::TcpListener {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for std::net::TcpListener {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromSocket for std::net::TcpListener {
+    #[inline]
+    fn from_socket(owned: OwnedSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedSocket> for std::net::TcpListener {
     #[inline]
     fn from_socket(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
@@ -287,11 +391,27 @@ impl IntoFd for std::net::UdpSocket {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<std::net::UdpSocket> for OwnedFd {
+    #[inline]
+    fn from(owned: std::net::UdpSocket) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoSocket for std::net::UdpSocket {
     #[inline]
     fn into_socket(self) -> OwnedSocket {
         unsafe { OwnedSocket::from_raw_socket(self.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<std::net::UdpSocket> for OwnedSocket {
+    #[inline]
+    fn from(owned: std::net::UdpSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
 
@@ -303,8 +423,24 @@ impl FromFd for std::net::UdpSocket {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for std::net::UdpSocket {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromSocket for std::net::UdpSocket {
+    #[inline]
+    fn from_socket(owned: OwnedSocket) -> Self {
+        unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedSocket> for std::net::UdpSocket {
     #[inline]
     fn from_socket(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
@@ -431,11 +567,27 @@ impl IntoFd for std::process::ChildStdin {
     }
 }
 
+#[cfg(unix)]
+impl From<std::process::ChildStdin> for OwnedFd {
+    #[inline]
+    fn from(owned: std::process::ChildStdin) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoHandle for std::process::ChildStdin {
     #[inline]
     fn into_handle(self) -> OwnedHandle {
         unsafe { OwnedHandle::from_raw_handle(self.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<std::process::ChildStdin> for OwnedHandle {
+    #[inline]
+    fn from(owned: std::process::ChildStdin) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
 
@@ -463,11 +615,27 @@ impl IntoFd for std::process::ChildStdout {
     }
 }
 
+#[cfg(unix)]
+impl From<std::process::ChildStdout> for OwnedFd {
+    #[inline]
+    fn from(owned: std::process::ChildStdout) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoHandle for std::process::ChildStdout {
     #[inline]
     fn into_handle(self) -> OwnedHandle {
         unsafe { OwnedHandle::from_raw_handle(self.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<std::process::ChildStdout> for OwnedHandle {
+    #[inline]
+    fn from(owned: std::process::ChildStdout) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
 
@@ -495,11 +663,27 @@ impl IntoFd for std::process::ChildStderr {
     }
 }
 
+#[cfg(unix)]
+impl From<std::process::ChildStderr> for OwnedFd {
+    #[inline]
+    fn from(owned: std::process::ChildStderr) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl IntoHandle for std::process::ChildStderr {
     #[inline]
     fn into_handle(self) -> OwnedHandle {
         unsafe { OwnedHandle::from_raw_handle(self.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<std::process::ChildStderr> for OwnedHandle {
+    #[inline]
+    fn from(owned: std::process::ChildStderr) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
 
@@ -511,10 +695,26 @@ impl FromFd for std::process::Stdio {
     }
 }
 
+#[cfg(unix)]
+impl From<OwnedFd> for std::process::Stdio {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromHandle for std::process::Stdio {
     #[inline]
     fn from_handle(owned: OwnedHandle) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedHandle> for std::process::Stdio {
+    #[inline]
+    fn from(owned: OwnedHandle) -> Self {
         unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }
@@ -535,6 +735,14 @@ impl IntoHandle for std::process::Child {
     }
 }
 
+#[cfg(windows)]
+impl From<std::process::Child> for OwnedHandle {
+    #[inline]
+    fn from(owned: std::process::Child) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
+    }
+}
+
 #[cfg(unix)]
 impl AsFd for std::os::unix::net::UnixStream {
     #[inline]
@@ -552,9 +760,25 @@ impl IntoFd for std::os::unix::net::UnixStream {
 }
 
 #[cfg(unix)]
+impl From<std::os::unix::net::UnixStream> for OwnedFd {
+    #[inline]
+    fn from(owned: std::os::unix::net::UnixStream) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
 impl FromFd for std::os::unix::net::UnixStream {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
+impl From<OwnedFd> for std::os::unix::net::UnixStream {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
@@ -576,9 +800,25 @@ impl IntoFd for std::os::unix::net::UnixListener {
 }
 
 #[cfg(unix)]
+impl From<std::os::unix::net::UnixListener> for OwnedFd {
+    #[inline]
+    fn from(owned: std::os::unix::net::UnixListener) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
 impl FromFd for std::os::unix::net::UnixListener {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
+impl From<OwnedFd> for std::os::unix::net::UnixListener {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
@@ -600,9 +840,25 @@ impl IntoFd for std::os::unix::net::UnixDatagram {
 }
 
 #[cfg(unix)]
+impl From<std::os::unix::net::UnixDatagram> for OwnedFd {
+    #[inline]
+    fn from(owned: std::os::unix::net::UnixDatagram) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
 impl FromFd for std::os::unix::net::UnixDatagram {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
+#[cfg(unix)]
+impl From<OwnedFd> for std::os::unix::net::UnixDatagram {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
         unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
     }
 }
@@ -620,5 +876,13 @@ impl<T> IntoHandle for std::thread::JoinHandle<T> {
     #[inline]
     fn into_handle(self) -> OwnedHandle {
         unsafe { OwnedHandle::from_raw_handle(self.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl<T> From<std::thread::JoinHandle<T>> for OwnedHandle {
+    #[inline]
+    fn from(owned: std::thread::JoinHandle<T>) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }

--- a/src/impls_std.rs
+++ b/src/impls_std.rs
@@ -282,7 +282,7 @@ impl FromSocket for std::net::TcpStream {
 #[cfg(windows)]
 impl From<OwnedSocket> for std::net::TcpStream {
     #[inline]
-    fn from_socket(owned: OwnedSocket) -> Self {
+    fn from(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
@@ -362,7 +362,7 @@ impl FromSocket for std::net::TcpListener {
 #[cfg(windows)]
 impl From<OwnedSocket> for std::net::TcpListener {
     #[inline]
-    fn from_socket(owned: OwnedSocket) -> Self {
+    fn from(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }
@@ -442,7 +442,7 @@ impl FromSocket for std::net::UdpSocket {
 #[cfg(windows)]
 impl From<OwnedSocket> for std::net::UdpSocket {
     #[inline]
-    fn from_socket(owned: OwnedSocket) -> Self {
+    fn from(owned: OwnedSocket) -> Self {
         unsafe { Self::from_raw_socket(owned.into_raw_socket()) }
     }
 }

--- a/src/impls_tokio.rs
+++ b/src/impls_tokio.rs
@@ -37,10 +37,26 @@ impl FromFd for tokio::fs::File {
     }
 }
 
+#[cfg(any(unix, target_os = "wasi"))]
+impl From<OwnedFd> for tokio::fs::File {
+    #[inline]
+    fn from(owned: OwnedFd) -> Self {
+        unsafe { Self::from_raw_fd(owned.into_raw_fd()) }
+    }
+}
+
 #[cfg(windows)]
 impl FromHandle for tokio::fs::File {
     #[inline]
     fn from_handle(owned: OwnedHandle) -> Self {
+        unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
+    }
+}
+
+#[cfg(windows)]
+impl From<OwnedHandle> for tokio::fs::File {
+    #[inline]
+    fn from(owned: OwnedHandle) -> Self {
         unsafe { Self::from_raw_handle(owned.into_raw_handle()) }
     }
 }


### PR DESCRIPTION
The std implementation uses `From` impls instead of `FromFd`/`IntoFd`.
io-lifetimes continues to support `FromFd`/`IntoFd` so that it can add
impls for third-party types. But for users who don't need that, add
the same `From` impls that std has.