### PR TITLE
Exclude tests and examples from the crates.io package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["api", "io"]
 categories = ["os", "rust-patterns"]
 edition = "2018"
 repository = "https://github.com/sunfishcode/io-lifetimes"
-exclude = ["/.github"]
+include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 
 [dependencies]
 # io-lifetimes only depends on libc/windows-sys for the ability to close


### PR DESCRIPTION
This shrinks the generated package size from 44K to 40K.