### PR TITLE
build: update async-std and disable default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,7 @@ include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 # temporary measure.
 
 # Optionally depend on async-std just to provide impls for its types for now.
-#
-# Enable the "unstable" feature so that we can implement traits for
-# `process::ChildStdin` etc.
-async-std = { version = "1.9.0", features = ["unstable"], optional = true }
+async-std = { version = "1.12.0", default-features = false, optional = true }
 # Optionally depend on tokio to implement traits for its types for now.
 tokio = { version = "1.6.0", features = ["io-std", "fs", "net", "process"], optional = true }
 # Optionally depend on socket2 to implement traits for its types for now.


### PR DESCRIPTION
The `unstable` feature is not required due to dependency update.
Default features are disabled to minimize dependency graph, which is
particularly relevant for `wasm32-wasi` target, since
default `async-std` feature set adds `socket2` dependency, which does
not support `wasm32-wasi`

This change should also massively speed up compilation

Before:
```
io-lifetimes v1.0.0-rc0 (/home/rvolosatovs/src/github.com/sunfishcode/io-lifetimes)
├── async-std v1.12.0
│   ├── async-channel v1.7.1
│   │   ├── concurrent-queue v1.2.4
│   │   │   └── cache-padded v1.2.0
│   │   ├── event-listener v2.5.3
│   │   └── futures-core v0.3.23
│   ├── async-global-executor v2.2.0
│   │   ├── async-channel v1.7.1 (*)
│   │   ├── async-executor v1.4.1
│   │   │   ├── async-task v4.3.0
│   │   │   ├── concurrent-queue v1.2.4 (*)
│   │   │   ├── fastrand v1.8.0
│   │   │   │   └── instant v0.1.12
│   │   │   │       └── cfg-if v1.0.0
│   │   │   ├── futures-lite v1.12.0
│   │   │   │   ├── fastrand v1.8.0 (*)
│   │   │   │   ├── futures-core v0.3.23
│   │   │   │   ├── futures-io v0.3.23
│   │   │   │   ├── memchr v2.5.0
│   │   │   │   ├── parking v2.0.0
│   │   │   │   ├── pin-project-lite v0.2.9
│   │   │   │   └── waker-fn v1.1.0
│   │   │   ├── once_cell v1.13.1
│   │   │   └── slab v0.4.7
│   │   │       [build-dependencies]
│   │   │       └── autocfg v1.1.0
│   │   ├── async-io v1.8.0
│   │   │   ├── concurrent-queue v1.2.4 (*)
│   │   │   ├── futures-lite v1.12.0 (*)
│   │   │   ├── log v0.4.17
│   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   └── value-bag v1.0.0-alpha.9
│   │   │   │       └── ctor v0.1.23 (proc-macro)
│   │   │   │           ├── quote v1.0.21
│   │   │   │           │   └── proc-macro2 v1.0.43
│   │   │   │           │       └── unicode-ident v1.0.3
│   │   │   │           └── syn v1.0.99
│   │   │   │               ├── proc-macro2 v1.0.43 (*)
│   │   │   │               ├── quote v1.0.21 (*)
│   │   │   │               └── unicode-ident v1.0.3
│   │   │   │       [build-dependencies]
│   │   │   │       └── version_check v0.9.4
│   │   │   ├── once_cell v1.13.1
│   │   │   ├── parking v2.0.0
│   │   │   ├── polling v2.3.0
│   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   └── log v0.4.17 (*)
│   │   │   │   [build-dependencies]
│   │   │   │   └── autocfg v1.1.0
│   │   │   ├── slab v0.4.7 (*)
│   │   │   ├── socket2 v0.4.4
│   │   │   └── waker-fn v1.1.0
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.1.0
│   │   ├── async-lock v2.5.0
│   │   │   └── event-listener v2.5.3
│   │   ├── blocking v1.2.0
│   │   │   ├── async-channel v1.7.1 (*)
│   │   │   ├── async-task v4.3.0
│   │   │   ├── atomic-waker v1.0.0
│   │   │   ├── fastrand v1.8.0 (*)
│   │   │   ├── futures-lite v1.12.0 (*)
│   │   │   └── once_cell v1.13.1
│   │   ├── futures-lite v1.12.0 (*)
│   │   ├── num_cpus v1.13.1
│   │   │   └── libc v0.2.132
│   │   └── once_cell v1.13.1
│   ├── async-io v1.8.0 (*)
│   ├── async-lock v2.5.0 (*)
│   ├── async-process v1.5.0
│   │   ├── cfg-if v1.0.0
│   │   ├── event-listener v2.5.3
│   │   ├── futures-lite v1.12.0 (*)
│   │   └── once_cell v1.13.1
│   │   [build-dependencies]
│   │   └── autocfg v1.1.0
│   ├── crossbeam-utils v0.8.11
│   │   ├── cfg-if v1.0.0
│   │   └── once_cell v1.13.1
│   ├── futures-channel v0.3.23
│   │   └── futures-core v0.3.23
│   ├── futures-core v0.3.23
│   ├── futures-io v0.3.23
│   ├── futures-lite v1.12.0 (*)
│   ├── gloo-timers v0.2.4
│   │   ├── futures-channel v0.3.23 (*)
│   │   ├── futures-core v0.3.23
│   │   ├── js-sys v0.3.59
│   │   │   └── wasm-bindgen v0.2.82
│   │   │       ├── cfg-if v1.0.0
│   │   │       └── wasm-bindgen-macro v0.2.82 (proc-macro)
│   │   │           ├── quote v1.0.21 (*)
│   │   │           └── wasm-bindgen-macro-support v0.2.82
│   │   │               ├── proc-macro2 v1.0.43 (*)
│   │   │               ├── quote v1.0.21 (*)
│   │   │               ├── syn v1.0.99 (*)
│   │   │               ├── wasm-bindgen-backend v0.2.82
│   │   │               │   ├── bumpalo v3.11.0
│   │   │               │   ├── log v0.4.17
│   │   │               │   │   ├── cfg-if v1.0.0
│   │   │               │   │   └── value-bag v1.0.0-alpha.9
│   │   │               │   │       └── ctor v0.1.23 (proc-macro) (*)
│   │   │               │   │       [build-dependencies]
│   │   │               │   │       └── version_check v0.9.4
│   │   │               │   ├── once_cell v1.13.1
│   │   │               │   ├── proc-macro2 v1.0.43 (*)
│   │   │               │   ├── quote v1.0.21 (*)
│   │   │               │   ├── syn v1.0.99 (*)
│   │   │               │   └── wasm-bindgen-shared v0.2.82
│   │   │               └── wasm-bindgen-shared v0.2.82
│   │   └── wasm-bindgen v0.2.82 (*)
│   ├── kv-log-macro v1.0.7
│   │   └── log v0.4.17 (*)
│   ├── log v0.4.17 (*)
│   ├── memchr v2.5.0
│   ├── once_cell v1.13.1
│   ├── pin-project-lite v0.2.9
│   ├── pin-utils v0.1.0
│   ├── slab v0.4.7 (*)
│   └── wasm-bindgen-futures v0.4.32
│       ├── cfg-if v1.0.0
│       ├── js-sys v0.3.59 (*)
│       └── wasm-bindgen v0.2.82 (*)
└── libc v0.2.132
```

After:
```
io-lifetimes v1.0.0-rc0 (/home/rvolosatovs/src/github.com/sunfishcode/io-lifetimes)
├── async-std v1.12.0
└── libc v0.2.132
```