### PR TITLE
fix: use correct traits in wasi tests

### DIFF
--- a/tests/niche-optimizations.rs
+++ b/tests/niche-optimizations.rs
@@ -11,7 +11,7 @@ use io_lifetimes::{BorrowedSocket, OwnedSocket};
 #[cfg(unix)]
 use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
 #[cfg(target_os = "wasi")]
-use std::os::wasi::io::{FromRawSocket, IntoRawSocket, RawFd};
+use std::os::wasi::io::{FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{FromRawSocket, IntoRawSocket, RawSocket};
 


### PR DESCRIPTION
Note, that tests still fail on `wasm32-wasi`, but at least the `niche-optimizations.rs` test compiles now.

```
$ cargo --version && cargo test --target wasm32-wasi
cargo 1.64.0-nightly (85b500cca 2022-07-24)
   Compiling io-lifetimes v1.0.0-rc0 (/home/rvolosatovs/src/github.com/sunfishcode/io-lifetimes)
warning: unused import: `io_lifetimes::example_ffi::*`
 --> examples/hello.rs:7:5
  |
7 | use io_lifetimes::example_ffi::*;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused imports: `Write`, `fs::File`, `self`
  --> examples/hello.rs:10:5
   |
10 |     fs::File,
   |     ^^^^^^^^
11 |     io::{self, Write},
   |          ^^^^  ^^^^^

warning: `io-lifetimes` (example "hello") generated 2 warnings
error[E0277]: the trait bound `OwnedFd: From<ChildStdout>` is not satisfied
   --> examples/easy-conversions.rs:19:45
    |
19  |     let mut file = File::from_into_filelike(child.stdout.take().unwrap());
    |                    ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<ChildStdout>` is not implemented for `OwnedFd`
    |                    |
    |                    required by a bound introduced by this call
    |
    = help: the following other types implement trait `From<T>`:
              <OwnedFd as From<File>>
              <OwnedFd as From<TcpListener>>
              <OwnedFd as From<TcpStream>>
              <OwnedFd as From<UdpSocket>>
    = note: required because of the requirements on the impl of `Into<OwnedFd>` for `ChildStdout`
    = note: required because of the requirements on the impl of `IntoFilelike` for `ChildStdout`
note: required by a bound in `from_into_filelike`
   --> /home/rvolosatovs/src/github.com/sunfishcode/io-lifetimes/src/portability.rs:395:34
    |
395 |     fn from_into_filelike<Owned: IntoFilelike>(owned: Owned) -> Self;
    |                                  ^^^^^^^^^^^^ required by this bound in `from_into_filelike`

error[E0599]: the method `as_filelike_view` exists for struct `Stdout`, but its trait bounds were not satisfied
  --> examples/portable-views.rs:17:27
   |
17 |     let metadata = stdout.as_filelike_view::<File>().metadata()?;
   |                           ^^^^^^^^^^^^^^^^ method cannot be called on `Stdout` due to unsatisfied trait bounds
   |
   = note: the following trait bounds were not satisfied:
           `Stdout: AsFd`
           which is required by `Stdout: AsFilelike`

warning: unused import: `io_lifetimes::AsFilelike`
 --> examples/portable-views.rs:4:5
  |
4 | use io_lifetimes::AsFilelike;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

For more information about this error, try `rustc --explain E0277`.
For more information about this error, try `rustc --explain E0599`.
warning: `io-lifetimes` (example "portable-views") generated 1 warning
error: could not compile `io-lifetimes` due to previous error; 1 warning emitted
warning: build failed, waiting for other jobs to finish...
error: could not compile `io-lifetimes` due to previous error
```