### PR TITLE
Disable async-std and other dependencies on WASI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, nightly, 1.48]
+        build: [stable, nightly]
         include:
           - build: stable
             os: ubuntu-latest
@@ -32,9 +32,6 @@ jobs:
           - build: nightly
             os: ubuntu-latest
             rust: nightly
-          - build: 1.48
-            os: ubuntu-latest
-            rust: 1.48
 
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
@@ -53,12 +50,38 @@ jobs:
     - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin
     - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin --all-features
 
+  check-1.48:
+    name: Check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [1.48]
+        include:
+          - build: 1.48
+            os: ubuntu-latest
+            rust: 1.48
+
+    env:
+      # -D warnings is commented out in our install-rust action; re-add it here.
+      RUSTFLAGS: -D warnings
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
+
+    - run: rustup target add x86_64-apple-darwin
+    - run: cargo check --workspace --release -vv
+    - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin
+
   check-windows:
     name: Check Windows
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, nightly, 1.48]
+        build: [stable, nightly]
         include:
           - build: stable
             os: windows-latest
@@ -66,6 +89,28 @@ jobs:
           - build: nightly
             os: windows-latest
             rust: nightly
+
+    env:
+      # -D warnings is commented out in our install-rust action; re-add it here.
+      RUSTFLAGS: -D warnings
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
+
+    - run: cargo check --workspace --release -vv
+    - run: cargo check --workspace --release -vv --all-features
+
+  check-windows-1.48:
+    name: Check Windows
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [1.48]
+        include:
           - build: 1.48
             os: windows-latest
             rust: 1.48
@@ -82,7 +127,6 @@ jobs:
         toolchain: ${{ matrix.rust }}
 
     - run: cargo check --workspace --release -vv
-    - run: cargo check --workspace --release -vv --all-features
 
   test:
     name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,45 @@ jobs:
         toolchain: stable
     - run: cargo fmt --all -- --check
 
+  check:
+    name: Check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [stable, nightly, 1.48]
+        include:
+          - build: stable
+            os: ubuntu-latest
+            rust: stable
+          - build: nightly
+            os: ubuntu-latest
+            rust: nightly
+          - build: 1.48
+            os: ubuntu-latest
+            rust: 1.48
+
+    env:
+      # -D warnings is commented out in our install-rust action; re-add it here.
+      RUSTFLAGS: -D warnings
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
+
+    - run: >
+        rustup target add
+        x86_64-apple-darwin
+        x86_64-pc-windows-msvc
+    - run: cargo check --workspace --release -vv
+    - run: cargo check --workspace --release -vv --all-features
+    - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin
+    - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin --all-features
+    - run: cargo check --workspace --release -vv --target=x86_64-pc-windows-msvc
+    - run: cargo check --workspace --release -vv --target=x86_64-pc-windows-msvc --all-features
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,16 +47,42 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
 
-    - run: >
-        rustup target add
-        x86_64-apple-darwin
-        x86_64-pc-windows-msvc
+    - run: rustup target add x86_64-apple-darwin
     - run: cargo check --workspace --release -vv
     - run: cargo check --workspace --release -vv --all-features
     - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin
     - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin --all-features
-    - run: cargo check --workspace --release -vv --target=x86_64-pc-windows-msvc
-    - run: cargo check --workspace --release -vv --target=x86_64-pc-windows-msvc --all-features
+
+  check-windows:
+    name: Check Windows
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [stable, nightly, 1.48]
+        include:
+          - build: stable
+            os: windows-latest
+            rust: stable
+          - build: nightly
+            os: windows-latest
+            rust: nightly
+          - build: 1.48
+            os: windows-latest
+            rust: 1.48
+
+    env:
+      # -D warnings is commented out in our install-rust action; re-add it here.
+      RUSTFLAGS: -D warnings
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
+
+    - run: cargo check --workspace --release -vv
+    - run: cargo check --workspace --release -vv --all-features
 
   test:
     name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin
     - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin --all-features
 
-  check-1.48:
+  check-1_48:
     name: Check
     runs-on: ${{ matrix.os }}
     strategy:
@@ -104,7 +104,7 @@ jobs:
     - run: cargo check --workspace --release -vv
     - run: cargo check --workspace --release -vv --all-features
 
-  check-windows-1.48:
+  check-windows-1_48:
     name: Check Windows
     runs-on: ${{ matrix.os }}
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,20 +17,31 @@ include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 # we'll prefer to have crates provide their own impls; this is just a
 # temporary measure.
 
-# Optionally depend on async-std just to provide impls for its types for now.
-async-std = { version = "1.12.0", default-features = false, optional = true }
-# Optionally depend on tokio to implement traits for its types for now.
-tokio = { version = "1.6.0", features = ["io-std", "fs", "net", "process"], optional = true }
-# Optionally depend on socket2 to implement traits for its types for now.
-socket2 = { version = "0.4.0", optional = true }
-# Optionally depend on mio to implement traits for its types for now.
-mio = { version = "0.8.0", features = ["net", "os-ext"], optional = true }
 # Optionally depend on fs_err to implement traits for its types for now.
 fs-err = { version = "2.6.0", optional = true }
 
 [target.'cfg(not(target_os = "wasi"))'.dependencies]
 # Optionally depend on os_pipe to implement traits for its types for now.
 os_pipe = { version = "1.0.0", optional = true }
+
+# The following dependencies allow io-lifetimes to define impls for various
+# third-party traits. This is only done in not(io_lifetimes_use_std) mode,
+# because when we're using the std types and traits, we can't define impls
+# on third-party traits, due to the orphan rule. Work is ongoing to add
+# the needs impls upstream.
+#
+# These dependencies are currently disabled on WASI, because we need to
+# enable some features which don't work on WASI yet. So for now, WASI users
+# will need to wait until the impls are added upstream.
+
+# Optionally depend on async-std just to provide impls for its types.
+async-std = { version = "1.12.0", optional = true }
+# Optionally depend on tokio to implement traits for its types.
+tokio = { version = "1.6.0", features = ["io-std", "fs", "net", "process"], optional = true }
+# Optionally depend on socket2 to implement traits for its types.
+socket2 = { version = "0.4.0", optional = true }
+# Optionally depend on mio to implement traits for its types.
+mio = { version = "0.8.0", features = ["net", "os-ext"], optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2.96", optional = true }

--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ they're simpler and safer to use. io-lifetimes doesn't include unsafe-io's
 `*ReadWrite*` or `*HandleOrSocket*` abstractions, and leaves these as features
 to be provided by separate layers on top.
 
+## Minimum Supported Rust Version (MSRV)
+
+This crate currently works on the version of [Rust on Debian stable], which is
+currently Rust 1.48. This policy may change in the future, in minor version
+releases, so users using a fixed version of Rust should pin to a specific
+version of this crate.
+
 [`OwnedFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/struct.OwnedFd.html
 [`BorrowedFd`]: https://doc.rust-lang.org/stable/std/os/unix/io/struct.BorrowedFd.html
 [RFC 3128]: https://github.com/rust-lang/rfcs/blob/master/text/3128-io-safety.md

--- a/src/impls_std.rs
+++ b/src/impls_std.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // Don't warn on `IntoFd` and `FromFd` impls.
+
 #[cfg(any(unix, target_os = "wasi"))]
 use crate::{AsFd, FromFd, IntoFd};
 #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
 
 #![deny(missing_docs)]
 #![cfg_attr(rustc_attrs, feature(rustc_attrs))]
-#![cfg_attr(all(io_lifetimes_use_std, target_os = "wasi"), feature(wasi_ext))]
 
 mod portability;
 mod traits;


### PR DESCRIPTION
Move the async-std, tokio, socket2, and mio dependencies into a
`not(target_os = "wasi")` dependency section. This fixes the problem
that the default features in async-std, which we need, depend on
socket2, which doesn't work on WASI yet.

The tradeoff here is that WASI users won't be able to make use of
io-lifetimes' impls for these third-party crate types. But we are
working to add these traits upstream, which will eventually make
this unnecessary.