### PR TITLE
Disable the contents of this crate on unknown platforms.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@
 #![deny(missing_docs)]
 // Work around https://github.com/rust-lang/rust/issues/103306.
 #![cfg_attr(all(wasi_ext, target_os = "wasi"), feature(wasi_ext))]
+// Currently supported platforms.
+#![cfg(any(unix, windows, target_os = "wasi"))]
 
 mod portability;
 mod traits;


### PR DESCRIPTION
Add `#![cfg(any(unix, windows, target_os = "wasi"))]` to the top-level lib.rs so that io-lifetimes can appear as a dependency on platforms even when it doesn't have support for them.