### PR TITLE
Remove the CI tests for io_lifetimes_use_std mode.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,34 +158,6 @@ jobs:
     - run: cargo test --workspace --features=fs-err,os_pipe # TODO: use --all-features
     - run: cargo test --workspace --no-default-features
 
-  test_use_std:
-    name: Test with std's types and traits
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        build: [ubuntu-nightly, windows-nightly]
-        include:
-          - build: ubuntu-nightly
-            os: ubuntu-latest
-            rust: nightly
-          - build: windows-nightly
-            os: windows-latest
-            rust: nightly
-
-    env:
-      RUSTFLAGS: --cfg io_lifetimes_use_std
-      RUSTDOCFLAGS: --cfg io_lifetimes_use_std
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: ./.github/actions/install-rust
-      with:
-        toolchain: ${{ matrix.rust }}
-    - run: cargo test --workspace --features=fs-err,os_pipe # TODO: use --all-features
-    - run: cargo test --workspace --no-default-features
-
   check_nightly:
     name: Check on Rust nightly
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This mode is now on by default on Rust >= 1.63, and off on Rust < 1.63, so we don't need a separate CI test rule for it now.