### PR TITLE
fix cross compilation with custom sysroot

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,72 +31,61 @@ fn use_feature(feature: &str) {
     println!("cargo:rustc-cfg={}", feature);
 }
 
-/// Test whether the rustc at `var("RUSTC")` supports the given feature.
-fn has_feature(feature: &str) -> bool {
+/// Test whether the rustc at `var("RUSTC")` can successfully compile the program.
+fn test_program<T: AsRef<str>>(test: T) -> bool {
     let out_dir = var("OUT_DIR").unwrap();
     let rustc = var("RUSTC").unwrap();
     let target = var("TARGET").unwrap();
 
-    let mut child = std::process::Command::new(rustc)
-        .arg("--crate-type=rlib") // Don't require `main`.
+    let mut cmd = if let Ok(wrapper) = var("CARGO_RUSTC_WRAPPER") {
+        let mut cmd = std::process::Command::new(wrapper);
+        // The wrapper's first argument is supposed to be the path to rustc.
+        cmd.arg(rustc);
+        cmd
+    } else {
+        std::process::Command::new(rustc)
+    };
+
+    cmd.arg("--crate-type=rlib") // Don't require `main`.
         .arg("--emit=metadata") // Do as little as possible but still parse.
         .arg("--target")
         .arg(target)
         .arg("--out-dir")
-        .arg(out_dir) // Put the output somewhere inconsequential.
+        .arg(out_dir);
+
+    // If Cargo wants to set RUSTFLAGS, use that.
+    if let Ok(rustflags) = var("CARGO_ENCODED_RUSTFLAGS") {
+        if !rustflags.is_empty() {
+            for arg in rustflags.split('\x1f') {
+                cmd.arg(arg);
+            }
+        }
+    }
+
+    let mut child = cmd
         .arg("-") // Read from stdin.
         .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
         .spawn()
         .unwrap();
 
-    writeln!(child.stdin.take().unwrap(), "#![feature({})]", feature).unwrap();
+    writeln!(child.stdin.take().unwrap(), "{}", test.as_ref()).unwrap();
 
     child.wait().unwrap().success()
+}
+
+/// Test whether the rustc at `var("RUSTC")` supports the given feature.
+fn has_feature(feature: &str) -> bool {
+    test_program(format!("#![feature({})]", feature))
 }
 
 /// Test whether the rustc at `var("RUSTC")` supports panic in `const fn`.
 fn has_panic_in_const_fn() -> bool {
-    let out_dir = var("OUT_DIR").unwrap();
-    let rustc = var("RUSTC").unwrap();
-    let target = var("TARGET").unwrap();
-
-    let mut child = std::process::Command::new(rustc)
-        .arg("--crate-type=rlib") // Don't require `main`.
-        .arg("--emit=metadata") // Do as little as possible but still parse.
-        .arg("--target")
-        .arg(target)
-        .arg("--out-dir")
-        .arg(out_dir) // Put the output somewhere inconsequential.
-        .arg("-") // Read from stdin.
-        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
-        .spawn()
-        .unwrap();
-
-    writeln!(child.stdin.take().unwrap(), "const fn foo() {{ panic!() }}").unwrap();
-
-    child.wait().unwrap().success()
+    test_program("const fn foo() {{ panic!() }}")
 }
 
 /// Test whether the rustc at `var("RUSTC")` supports the I/O safety feature.
 fn has_io_safety() -> bool {
-    let out_dir = var("OUT_DIR").unwrap();
-    let rustc = var("RUSTC").unwrap();
-    let target = var("TARGET").unwrap();
-
-    let mut child = std::process::Command::new(rustc)
-        .arg("--crate-type=rlib") // Don't require `main`.
-        .arg("--emit=metadata") // Do as little as possible but still parse.
-        .arg("--target")
-        .arg(target)
-        .arg("--out-dir")
-        .arg(out_dir) // Put the output somewhere inconsequential.
-        .arg("-") // Read from stdin.
-        .stdin(std::process::Stdio::piped()) // Stdin is a pipe.
-        .spawn()
-        .unwrap();
-
-    writeln!(
-        child.stdin.take().unwrap(),
+    test_program(
         "\
     #[cfg(unix)]\n\
     use std::os::unix::io::OwnedFd as Owned;\n\
@@ -106,9 +95,6 @@ fn has_io_safety() -> bool {
     use std::os::windows::io::OwnedHandle as Owned;\n\
     \n\
     pub type Success = Owned;\n\
-    "
+    ",
     )
-    .unwrap();
-
-    child.wait().unwrap().success()
 }


### PR DESCRIPTION
compiling rust programs in yocto uses a custom target triple with a custom sysroot
not specifying the sysroot when executing rustc can lead to errors like "can't find crate for `std`"
this patch forwards the sysroot for testing features