### PR TITLE
Downgrade to socket2 0.4.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,11 @@ os_pipe = { version = "1.0.0", features = ["io_safety"], optional = true }
 async-std = { version = "1.12.0", optional = true }
 # Optionally depend on tokio to implement traits for its types.
 tokio = { version = "1.6.0", features = ["io-std", "fs", "net", "process"], optional = true }
-# Optionally depend on socket2 to implement traits for its types.
-socket2 = { version = "0.5.0", optional = true }
+# Optionally depend on socket2 to implement traits for its types. This uses
+# 0.4 because 0.5 has an MSRV of 1.63, which is the version where io-lifetimes
+# switches to using the types and traits from std ("io_safety_is_in_std"),
+# and disables the third-party impls.
+socket2 = { version = "0.4.0", optional = true }
 # Optionally depend on mio to implement traits for its types.
 mio = { version = "0.8.0", features = ["net", "os-ext"], optional = true }
 


### PR DESCRIPTION
Revert #62; socket 0.5 has an MSRV of 1.63, at which point we're no longer providing third-party impls, so 0.4.0 is the version which is useful to support.