### PR TITLE
add RustyHermit support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ socket2 = { version = "0.4.0", optional = true }
 # Optionally depend on mio to implement traits for its types.
 mio = { version = "0.8.0", features = ["net", "os-ext"], optional = true }
 
+[target.'cfg(target_os = "hermit")'.dependencies]
+hermit-abi = { version = "0.3", optional = true }
+
 [target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2.96", optional = true }
 
@@ -63,4 +66,4 @@ features = [
 
 [features]
 default = ["close"]
-close = ["libc", "windows-sys"]
+close = ["libc", "hermit-abi", "windows-sys"]

--- a/src/example_ffi.rs
+++ b/src/example_ffi.rs
@@ -3,12 +3,12 @@
 #![cfg_attr(not(io_safety_is_in_std), allow(unused_imports))]
 #![allow(missing_docs)]
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use crate::{BorrowedFd, OwnedFd};
 #[cfg(windows)]
 use crate::{BorrowedHandle, HandleOrInvalid};
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use libc::{c_char, c_int, c_void, size_t, ssize_t};
 #[cfg(windows)]
 use {
@@ -23,7 +23,10 @@ use {
 };
 
 // Declare a few FFI functions ourselves, to show off the FFI ergonomics.
-#[cfg(all(io_safety_is_in_std, any(unix, target_os = "wasi")))]
+#[cfg(all(
+    io_safety_is_in_std,
+    any(unix, target_os = "wasi", target_os = "hermit")
+))]
 extern "C" {
     pub fn open(pathname: *const c_char, flags: c_int, ...) -> Option<OwnedFd>;
 }

--- a/src/impls_std.rs
+++ b/src/impls_std.rs
@@ -1,13 +1,15 @@
 #![allow(deprecated)] // Don't warn on `IntoFd` and `FromFd` impls.
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use crate::{AsFd, FromFd, IntoFd};
 #[cfg(windows)]
 use crate::{AsHandle, AsSocket, FromHandle, FromSocket, IntoHandle, IntoSocket};
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use crate::{BorrowedFd, OwnedFd};
 #[cfg(windows)]
 use crate::{BorrowedHandle, BorrowedSocket, HandleOrInvalid, OwnedHandle, OwnedSocket};
+#[cfg(target_os = "hermit")]
+use std::os::hermit::io::{AsRawFd, FromRawFd, IntoRawFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 #[cfg(target_os = "wasi")]
@@ -17,7 +19,7 @@ use std::os::windows::io::{
     AsRawHandle, AsRawSocket, FromRawHandle, FromRawSocket, IntoRawHandle, IntoRawSocket,
 };
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl AsFd for BorrowedFd<'_> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -41,7 +43,7 @@ impl AsSocket for BorrowedSocket<'_> {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl AsFd for OwnedFd {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -65,7 +67,7 @@ impl AsSocket for OwnedSocket {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl IntoFd for OwnedFd {
     #[inline]
     fn into_fd(self) -> OwnedFd {
@@ -89,7 +91,7 @@ impl IntoSocket for OwnedSocket {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl FromFd for OwnedFd {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
@@ -129,7 +131,7 @@ impl From<OwnedHandle> for HandleOrInvalid {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl AsFd for std::fs::File {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -145,7 +147,7 @@ impl AsHandle for std::fs::File {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl IntoFd for std::fs::File {
     #[inline]
     fn into_fd(self) -> OwnedFd {
@@ -153,7 +155,7 @@ impl IntoFd for std::fs::File {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl From<std::fs::File> for OwnedFd {
     #[inline]
     fn from(owned: std::fs::File) -> Self {
@@ -177,7 +179,7 @@ impl From<std::fs::File> for OwnedHandle {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl FromFd for std::fs::File {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
@@ -185,7 +187,7 @@ impl FromFd for std::fs::File {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl From<OwnedFd> for std::fs::File {
     #[inline]
     fn from(owned: OwnedFd) -> Self {
@@ -209,7 +211,7 @@ impl From<OwnedHandle> for std::fs::File {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl AsFd for std::net::TcpStream {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -225,7 +227,7 @@ impl AsSocket for std::net::TcpStream {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl IntoFd for std::net::TcpStream {
     #[inline]
     fn into_fd(self) -> OwnedFd {
@@ -233,7 +235,7 @@ impl IntoFd for std::net::TcpStream {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl From<std::net::TcpStream> for OwnedFd {
     #[inline]
     fn from(owned: std::net::TcpStream) -> Self {
@@ -257,7 +259,7 @@ impl From<std::net::TcpStream> for OwnedSocket {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl FromFd for std::net::TcpStream {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
@@ -265,7 +267,7 @@ impl FromFd for std::net::TcpStream {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl From<OwnedFd> for std::net::TcpStream {
     #[inline]
     fn from(owned: OwnedFd) -> Self {
@@ -289,7 +291,7 @@ impl From<OwnedSocket> for std::net::TcpStream {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl AsFd for std::net::TcpListener {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -305,7 +307,7 @@ impl AsSocket for std::net::TcpListener {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl IntoFd for std::net::TcpListener {
     #[inline]
     fn into_fd(self) -> OwnedFd {
@@ -313,7 +315,7 @@ impl IntoFd for std::net::TcpListener {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl From<std::net::TcpListener> for OwnedFd {
     #[inline]
     fn from(owned: std::net::TcpListener) -> Self {
@@ -337,7 +339,7 @@ impl From<std::net::TcpListener> for OwnedSocket {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl FromFd for std::net::TcpListener {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
@@ -345,7 +347,7 @@ impl FromFd for std::net::TcpListener {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl From<OwnedFd> for std::net::TcpListener {
     #[inline]
     fn from(owned: OwnedFd) -> Self {
@@ -369,7 +371,7 @@ impl From<OwnedSocket> for std::net::TcpListener {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl AsFd for std::net::UdpSocket {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -385,7 +387,7 @@ impl AsSocket for std::net::UdpSocket {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl IntoFd for std::net::UdpSocket {
     #[inline]
     fn into_fd(self) -> OwnedFd {
@@ -393,7 +395,7 @@ impl IntoFd for std::net::UdpSocket {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl From<std::net::UdpSocket> for OwnedFd {
     #[inline]
     fn from(owned: std::net::UdpSocket) -> Self {
@@ -417,7 +419,7 @@ impl From<std::net::UdpSocket> for OwnedSocket {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl FromFd for std::net::UdpSocket {
     #[inline]
     fn from_fd(owned: OwnedFd) -> Self {
@@ -425,7 +427,7 @@ impl FromFd for std::net::UdpSocket {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl From<OwnedFd> for std::net::UdpSocket {
     #[inline]
     fn from(owned: OwnedFd) -> Self {
@@ -449,7 +451,7 @@ impl From<OwnedSocket> for std::net::UdpSocket {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl AsFd for std::io::Stdin {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -465,7 +467,7 @@ impl AsHandle for std::io::Stdin {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<'a> AsFd for std::io::StdinLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -481,7 +483,7 @@ impl<'a> AsHandle for std::io::StdinLock<'a> {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl AsFd for std::io::Stdout {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -497,7 +499,7 @@ impl AsHandle for std::io::Stdout {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<'a> AsFd for std::io::StdoutLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -513,7 +515,7 @@ impl<'a> AsHandle for std::io::StdoutLock<'a> {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl AsFd for std::io::Stderr {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -529,7 +531,7 @@ impl AsHandle for std::io::Stderr {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<'a> AsFd for std::io::StderrLock<'a> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 // Work around <https://github.com/rust-lang/rust/issues/103306>.
 #![cfg_attr(all(wasi_ext, target_os = "wasi"), feature(wasi_ext))]
 // Currently supported platforms.
-#![cfg(any(unix, windows, target_os = "wasi"))]
+#![cfg(any(unix, windows, target_os = "wasi", target_os = "hermit"))]
 
 mod portability;
 mod traits;
@@ -42,12 +42,12 @@ mod types;
 mod impls_std;
 
 #[cfg(not(io_safety_is_in_std))]
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub use traits::AsFd;
 #[cfg(not(io_safety_is_in_std))]
 #[cfg(windows)]
 pub use traits::{AsHandle, AsSocket};
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 #[allow(deprecated)]
 pub use traits::{FromFd, IntoFd};
 #[cfg(windows)]
@@ -55,7 +55,7 @@ pub use traits::{FromFd, IntoFd};
 pub use traits::{FromHandle, FromSocket, IntoHandle, IntoSocket};
 
 #[cfg(not(io_safety_is_in_std))]
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub use types::{BorrowedFd, OwnedFd};
 #[cfg(not(io_safety_is_in_std))]
 #[cfg(windows)]
@@ -64,6 +64,9 @@ pub use types::{
     OwnedHandle, OwnedSocket,
 };
 
+#[cfg(io_safety_is_in_std)]
+#[cfg(target_os = "hermit")]
+pub use std::os::hermit::io::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(io_safety_is_in_std)]
 #[cfg(unix)]
 pub use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
@@ -89,7 +92,7 @@ pub use std::os::windows::io::{
 // So we define `FromFd`/`IntoFd` traits, and implement them in terms of
 // `From`/`Into`,
 #[cfg(io_safety_is_in_std)]
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 #[allow(deprecated)]
 impl<T: From<OwnedFd>> FromFd for T {
     #[inline]
@@ -98,7 +101,7 @@ impl<T: From<OwnedFd>> FromFd for T {
     }
 }
 #[cfg(io_safety_is_in_std)]
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 #[allow(deprecated)]
 impl<T> IntoFd for T
 where

--- a/src/portability.rs
+++ b/src/portability.rs
@@ -5,7 +5,7 @@
 //! layer of portability over this difference.
 
 use crate::views::{FilelikeView, FilelikeViewType, SocketlikeView, SocketlikeViewType};
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use crate::{AsFd, BorrowedFd, OwnedFd};
 #[cfg(windows)]
 use crate::{AsHandle, AsSocket, BorrowedHandle, BorrowedSocket, OwnedHandle, OwnedSocket};
@@ -14,7 +14,7 @@ use crate::{AsHandle, AsSocket, BorrowedHandle, BorrowedSocket, OwnedHandle, Own
 ///
 /// This is a portability abstraction over Unix-like [`BorrowedFd`] and
 /// Windows' `BorrowedHandle`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub type BorrowedFilelike<'filelike> = BorrowedFd<'filelike>;
 
 /// A reference to a filelike object.
@@ -28,7 +28,7 @@ pub type BorrowedFilelike<'filelike> = BorrowedHandle<'filelike>;
 ///
 /// This is a portability abstraction over Unix-like [`BorrowedFd`] and
 /// Windows' `BorrowedSocket`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub type BorrowedSocketlike<'socketlike> = BorrowedFd<'socketlike>;
 
 /// A reference to a socketlike object.
@@ -42,7 +42,7 @@ pub type BorrowedSocketlike<'socketlike> = BorrowedSocket<'socketlike>;
 ///
 /// This is a portability abstraction over Unix-like [`OwnedFd`] and
 /// Windows' `OwnedHandle`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub type OwnedFilelike = OwnedFd;
 
 /// An owned filelike object.
@@ -56,7 +56,7 @@ pub type OwnedFilelike = OwnedHandle;
 ///
 /// This is a portability abstraction over Unix-like [`OwnedFd`] and
 /// Windows' `OwnedSocket`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub type OwnedSocketlike = OwnedFd;
 
 /// An owned socketlike object.
@@ -71,7 +71,7 @@ pub type OwnedSocketlike = OwnedSocket;
 /// This is a portability abstraction over Unix-like [`AsFd`] and Windows'
 /// `AsHandle`. It also provides the `as_filelike_view` convenience function
 /// providing typed views.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait AsFilelike: AsFd {
     /// Borrows the reference.
     ///
@@ -107,7 +107,7 @@ pub trait AsFilelike: AsFd {
     fn as_filelike_view<Target: FilelikeViewType>(&self) -> FilelikeView<'_, Target>;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: AsFd> AsFilelike for T {
     #[inline]
     fn as_filelike(&self) -> BorrowedFilelike<'_> {
@@ -180,7 +180,7 @@ impl<T: AsHandle> AsFilelike for T {
 /// This is a portability abstraction over Unix-like [`AsFd`] and Windows'
 /// `AsSocket`. It also provides the `as_socketlike_view` convenience
 /// function providing typed views.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait AsSocketlike: AsFd {
     /// Borrows the reference.
     fn as_socketlike(&self) -> BorrowedSocketlike<'_>;
@@ -204,7 +204,7 @@ pub trait AsSocketlike: AsFd {
     fn as_socketlike_view<Target: SocketlikeViewType>(&self) -> SocketlikeView<'_, Target>;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: AsFd> AsSocketlike for T {
     #[inline]
     fn as_socketlike(&self) -> BorrowedSocketlike<'_> {
@@ -263,7 +263,7 @@ impl<T: AsSocket> AsSocketlike for T {
 ///
 /// This is a portability abstraction over Unix-like [`Into<OwnedFd>`] and
 /// Windows' `Into<OwnedHandle>`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait IntoFilelike: Into<OwnedFd> {
     /// Consumes this object, returning the underlying filelike object.
     ///
@@ -281,7 +281,7 @@ pub trait IntoFilelike: Into<OwnedFd> {
     fn into_filelike(self) -> OwnedFilelike;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: Into<OwnedFd>> IntoFilelike for T {
     #[inline]
     fn into_filelike(self) -> OwnedFilelike {
@@ -313,13 +313,13 @@ impl<T: Into<OwnedHandle>> IntoFilelike for T {
 ///
 /// This is a portability abstraction over Unix-like [`Into<OwnedFd>`] and
 /// Windows' `Into<OwnedSocket>`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait IntoSocketlike: Into<OwnedFd> {
     /// Consumes this object, returning the underlying socketlike object.
     fn into_socketlike(self) -> OwnedSocketlike;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: Into<OwnedFd>> IntoSocketlike for T {
     #[inline]
     fn into_socketlike(self) -> OwnedSocketlike {
@@ -364,7 +364,7 @@ impl<T: Into<OwnedSocket>> IntoSocketlike for T {
 /// This is a portability abstraction over Unix-like [`From<OwnedFd>`] and
 /// Windows' `From<OwnedHandle>`. It also provides the `from_into_filelike`
 /// convenience function providing simplified from+into conversions.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait FromFilelike: From<OwnedFd> {
     /// Constructs a new instance of `Self` from the given filelike object.
     ///
@@ -399,7 +399,7 @@ pub trait FromFilelike: From<OwnedFd> {
     fn from_into_filelike<Owned: IntoFilelike>(owned: Owned) -> Self;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: From<OwnedFd>> FromFilelike for T {
     #[inline]
     fn from_filelike(owned: OwnedFilelike) -> Self {
@@ -473,7 +473,7 @@ impl<T: From<OwnedHandle>> FromFilelike for T {
 /// Windows' `From<OwnedSocketFrom<OwnedSocket>` It also provides the
 /// `from_into_socketlike` convenience function providing simplified from+into
 /// conversions.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait FromSocketlike: From<OwnedFd> {
     /// Constructs a new instance of `Self` from the given socketlike object.
     fn from_socketlike(owned: OwnedSocketlike) -> Self;
@@ -483,7 +483,7 @@ pub trait FromSocketlike: From<OwnedFd> {
     fn from_into_socketlike<Owned: IntoSocketlike>(owned: Owned) -> Self;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: From<OwnedFd>> FromSocketlike for T {
     #[inline]
     fn from_socketlike(owned: OwnedSocketlike) -> Self {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -4,6 +4,8 @@
 //! handles are distinct from socket descriptors. This file provides a minimal
 //! layer of portability over this difference.
 
+#[cfg(target_os = "hermit")]
+use std::os::hermit::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(target_os = "wasi")]
@@ -18,7 +20,7 @@ use std::os::windows::io::{
 ///
 /// This is a portability abstraction over Unix-like [`RawFd`] and
 /// Windows' `RawHandle`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub type RawFilelike = RawFd;
 
 /// A raw filelike object.
@@ -32,7 +34,7 @@ pub type RawFilelike = RawHandle;
 ///
 /// This is a portability abstraction over Unix-like [`RawFd`] and
 /// Windows' `RawSocket`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub type RawSocketlike = RawFd;
 
 /// A raw socketlike object.
@@ -46,13 +48,13 @@ pub type RawSocketlike = RawSocket;
 ///
 /// This is a portability abstraction over Unix-like [`AsRawFd`] and Windows'
 /// `AsRawHandle`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait AsRawFilelike: AsRawFd {
     /// Returns the raw value.
     fn as_raw_filelike(&self) -> RawFilelike;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: AsRawFd> AsRawFilelike for T {
     #[inline]
     fn as_raw_filelike(&self) -> RawFilelike {
@@ -78,13 +80,13 @@ impl<T: AsRawHandle> AsRawFilelike for T {
 
 /// This is a portability abstraction over Unix-like [`AsRawFd`] and Windows'
 /// `AsRawSocket`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait AsRawSocketlike: AsRawFd {
     /// Returns the raw value.
     fn as_raw_socketlike(&self) -> RawSocketlike;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: AsRawFd> AsRawSocketlike for T {
     #[inline]
     fn as_raw_socketlike(&self) -> RawSocketlike {
@@ -110,13 +112,13 @@ impl<T: AsRawSocket> AsRawSocketlike for T {
 
 /// This is a portability abstraction over Unix-like [`IntoRawFd`] and Windows'
 /// `IntoRawHandle`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait IntoRawFilelike: IntoRawFd {
     /// Returns the raw value.
     fn into_raw_filelike(self) -> RawFilelike;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: IntoRawFd> IntoRawFilelike for T {
     #[inline]
     fn into_raw_filelike(self) -> RawFilelike {
@@ -142,13 +144,13 @@ impl<T: IntoRawHandle> IntoRawFilelike for T {
 
 /// This is a portability abstraction over Unix-like [`IntoRawFd`] and Windows'
 /// `IntoRawSocket`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait IntoRawSocketlike: IntoRawFd {
     /// Returns the raw value.
     fn into_raw_socketlike(self) -> RawSocketlike;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: IntoRawFd> IntoRawSocketlike for T {
     #[inline]
     fn into_raw_socketlike(self) -> RawSocketlike {
@@ -174,7 +176,7 @@ impl<T: IntoRawSocket> IntoRawSocketlike for T {
 
 /// This is a portability abstraction over Unix-like [`FromRawFd`] and Windows'
 /// `FromRawHandle`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait FromRawFilelike: FromRawFd {
     /// Constructs `Self` from the raw value.
     ///
@@ -188,7 +190,7 @@ pub trait FromRawFilelike: FromRawFd {
     unsafe fn from_raw_filelike(raw: RawFilelike) -> Self;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: FromRawFd> FromRawFilelike for T {
     #[inline]
     unsafe fn from_raw_filelike(raw: RawFilelike) -> Self {
@@ -214,7 +216,7 @@ impl<T: FromRawHandle> FromRawFilelike for T {
 
 /// This is a portability abstraction over Unix-like [`FromRawFd`] and Windows'
 /// `FromRawSocket`.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait FromRawSocketlike: FromRawFd {
     /// Constructs `Self` from the raw value.
     ///
@@ -228,7 +230,7 @@ pub trait FromRawSocketlike: FromRawFd {
     unsafe fn from_raw_socketlike(raw: RawSocketlike) -> Self;
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: FromRawFd> FromRawSocketlike for T {
     #[inline]
     unsafe fn from_raw_socketlike(raw: RawSocketlike) -> Self {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,7 @@
 #[cfg(not(io_safety_is_in_std))]
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use crate::BorrowedFd;
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use crate::OwnedFd;
 #[cfg(not(io_safety_is_in_std))]
 #[cfg(windows)]
@@ -15,7 +15,7 @@ use crate::{OwnedHandle, OwnedSocket};
 /// call the method. Windows platforms have a corresponding `AsHandle` and
 /// `AsSocket` set of traits.
 #[cfg(not(io_safety_is_in_std))]
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait AsFd {
     /// Borrows the file descriptor.
     ///
@@ -63,7 +63,7 @@ pub trait AsSocket {
 
 /// A trait to express the ability to consume an object and acquire ownership
 /// of its file descriptor.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 #[deprecated(
     since = "1.0.0",
     note = "`IntoFd` is replaced by `From<...> for OwnedFd` or `Into<OwnedFd>`"
@@ -123,7 +123,7 @@ pub trait IntoSocket {
 
 /// A trait to express the ability to construct an object from a file
 /// descriptor.
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 pub trait FromFd {
     /// Constructs a new instance of `Self` from the given file descriptor.
     ///
@@ -236,7 +236,7 @@ pub trait FromSocket {
 }
 
 #[cfg(not(io_safety_is_in_std))]
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: AsFd> AsFd for &T {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -245,7 +245,7 @@ impl<T: AsFd> AsFd for &T {
 }
 
 #[cfg(not(io_safety_is_in_std))]
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 impl<T: AsFd> AsFd for &mut T {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {

--- a/src/views.rs
+++ b/src/views.rs
@@ -9,7 +9,7 @@ use crate::raw::{
     AsRawFilelike, AsRawSocketlike, FromRawFilelike, FromRawSocketlike, IntoRawFilelike,
     IntoRawSocketlike, RawFilelike, RawSocketlike,
 };
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 use crate::OwnedFd;
 use crate::{
     AsFilelike, AsSocketlike, FromFilelike, FromSocketlike, IntoFilelike, IntoSocketlike,
@@ -207,7 +207,7 @@ impl<Target: SocketlikeViewType> fmt::Debug for SocketlikeView<'_, Target> {
     }
 }
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(any(unix, target_os = "wasi", target_os = "hermit"))]
 unsafe impl FilelikeViewType for OwnedFd {}
 #[cfg(windows)]
 unsafe impl FilelikeViewType for OwnedHandle {}
@@ -224,24 +224,24 @@ unsafe impl SocketlikeViewType for std::os::unix::net::UnixListener {}
 
 #[cfg(unix)]
 unsafe impl SocketlikeViewType for std::os::unix::net::UnixDatagram {}
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_os = "hermit")))]
 #[cfg(feature = "os_pipe")]
 unsafe impl FilelikeViewType for os_pipe::PipeWriter {}
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_os = "hermit")))]
 #[cfg(feature = "os_pipe")]
 unsafe impl FilelikeViewType for os_pipe::PipeReader {}
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_os = "hermit")))]
 #[cfg(feature = "socket2")]
 unsafe impl SocketlikeViewType for socket2::Socket {}
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_os = "hermit")))]
 #[cfg(feature = "async_std")]
 unsafe impl SocketlikeViewType for async_std::net::TcpStream {}
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_os = "hermit")))]
 #[cfg(feature = "async_std")]
 unsafe impl SocketlikeViewType for async_std::net::TcpListener {}
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_os = "hermit")))]
 #[cfg(feature = "async_std")]
 unsafe impl SocketlikeViewType for async_std::net::UdpSocket {}
 #[cfg(unix)]


### PR DESCRIPTION
RusytHermit is a library operating system, which is completely written in Rust. It provides unix-like file descriptors. Consequently, the implementation has some similarites to the Unix support.