### PR TITLE
Use `RUSTC_WRAPPER` instead of `CARGO_RUSTC_WRAPPER`.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -47,7 +47,7 @@ fn can_compile<T: AsRef<str>>(test: T) -> bool {
     let rustc = var("RUSTC").unwrap();
     let target = var("TARGET").unwrap();
 
-    let mut cmd = if let Ok(wrapper) = var("CARGO_RUSTC_WRAPPER") {
+    let mut cmd = if let Ok(wrapper) = var("RUSTC_WRAPPER") {
         let mut cmd = std::process::Command::new(wrapper);
         // The wrapper's first argument is supposed to be the path to rustc.
         cmd.arg(rustc);


### PR DESCRIPTION
Similar to dtolnay/anyhow#248, and as suggested [here], check `RUSTC_WRAPPER` instead of `CARGO_RUSTC_WRAPPER`.

[here]: https://github.com/bytecodealliance/rustix/pull/544#discussion_r1140467731