### PR TITLE
Restore the `os_pipe` and other optional dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,24 @@ repository = "https://github.com/sunfishcode/io-lifetimes"
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 rust-version = "1.63"
 
+[dependencies]
+# io-lifetimes only depends on libc/windows-sys for the ability to close
+# and duplicate fds/handles/sockets. The following are just optional
+# dependencies to add foreign-type impls for the traits.
+
+[target.'cfg(not(target_os = "wasi"))'.dependencies]
+# Optionally depend on os_pipe to implement traits for its types for now.
+os_pipe = { version = "1.0.0", features = ["io_safety"], optional = true }
+
+# Optionally depend on async-std just to provide impls for its types.
+async-std = { version = "1.12.0", optional = true }
+# Optionally depend on tokio to implement traits for its types.
+tokio = { version = "1.6.0", features = ["io-std", "fs", "net", "process"], optional = true }
+# Optionally depend on socket2 to implement traits for its types.
+socket2 = { version = "0.5.0", optional = true }
+# Optionally depend on mio to implement traits for its types.
+mio = { version = "0.8.0", features = ["net", "os-ext"], optional = true }
+
 [target.'cfg(target_os = "hermit")'.dependencies]
 hermit-abi = { version = "0.3", optional = true }
 


### PR DESCRIPTION
These were removed when support for pre-Rust 1.63 was dropped as the main I/O lifetimes impls aren't needed anymore, however they are still useful for providing impls for `FilelikeViewType` and `SocketlikeViewType`.