### PR TITLE
Fix docs.rs not working

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 #![cfg_attr(all(wasi_ext, target_os = "wasi"), feature(wasi_ext))]
 // Currently supported platforms.
 #![cfg(any(unix, windows, target_os = "wasi", target_os = "hermit"))]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 mod portability;
 mod traits;


### PR DESCRIPTION
Documentation on docs.rs fails because of a missing feature flag: https://docs.rs/crate/io-lifetimes/2.0.1/builds/849756