### PR TITLE
Update dependencies and bump MSRV to 1.70.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,16 +50,16 @@ jobs:
     - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin
     - run: cargo check --workspace --release -vv --target=x86_64-apple-darwin --no-default-features
 
-  check-1_63:
+  check-1_70:
     name: Check
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [1.63]
+        build: [1.70]
         include:
-          - build: 1.63
+          - build: 1.70
             os: ubuntu-latest
-            rust: 1.63
+            rust: 1.70
 
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
@@ -104,16 +104,16 @@ jobs:
     - run: cargo check --workspace --release -vv
     - run: cargo check --workspace --release -vv --no-default-features
 
-  check-windows-1_63:
+  check-windows-1_70:
     name: Check Windows
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [1.63]
+        build: [1.70]
         include:
-          - build: 1.63
+          - build: 1.70
             os: windows-latest
-            rust: 1.63
+            rust: 1.70
 
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [1.70]
+        build: [1.70.0]
         include:
-          - build: 1.70
+          - build: 1.70.0
             os: ubuntu-latest
-            rust: 1.70
+            rust: 1.70.0
 
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.
@@ -109,11 +109,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [1.70]
+        build: [1.70.0]
         include:
-          - build: 1.70
+          - build: 1.70.0
             os: windows-latest
-            rust: 1.70
+            rust: 1.70.0
 
     env:
       # -D warnings is commented out in our install-rust action; re-add it here.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["os", "rust-patterns"]
 edition = "2021"
 repository = "https://github.com/sunfishcode/io-lifetimes"
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
-rust-version = "1.63"
+rust-version = "1.70"
 
 [dependencies]
 # io-lifetimes only depends on libc/windows-sys for the ability to close
@@ -27,16 +27,16 @@ tokio = { version = "1.6.0", features = ["io-std", "fs", "net", "process"], opti
 # Optionally depend on socket2 to implement traits for its types.
 socket2 = { version = "0.6.0", optional = true }
 # Optionally depend on mio to implement traits for its types.
-mio = { version = "0.8.0", features = ["net", "os-ext"], optional = true }
+mio = { version = "1.0.0", features = ["net", "os-ext"], optional = true }
 
 [target.'cfg(target_os = "hermit")'.dependencies]
-hermit-abi = { version = ">=0.3, <=0.4", optional = true }
+hermit-abi = { version = ">=0.3, <=0.5", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2.96", optional = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = ">=0.52, <=0.59"
+version = ">=0.52, <=0.60"
 optional = true
 features = [
     "Win32_Foundation",

--- a/src/portability.rs
+++ b/src/portability.rs
@@ -226,7 +226,7 @@ impl<T: AsFd> AsSocketlike for T {
 #[cfg(windows)]
 pub trait AsSocketlike: AsSocket {
     /// Borrows the reference.
-    fn as_socketlike(&self) -> BorrowedSocketlike;
+    fn as_socketlike(&self) -> BorrowedSocketlike<'_>;
 
     /// Return a borrowing view of a resource which dereferences to a
     /// `&Target`.


### PR DESCRIPTION
Update windows-sys, mio, and hermit-abi dependencies to support the latest versions.

Bump the MSRV to 1.70, to accomodate socket2 0.6.